### PR TITLE
Add setup automation for Python environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Project Setup
+
+This repository provides analysis utilities for vegetation indices. Use the provided setup script to configure a local Python environment.
+
+## Prerequisites
+- Python 3.12 available on your PATH
+- Access to a POSIX-compatible shell (macOS, Linux, or WSL)
+
+## Initial Setup
+1. Clone the repository.
+2. Make the setup script executable (first time only):
+   ```bash
+   chmod +x setup.sh
+   ```
+3. Run the setup script to create the `venv` virtual environment and install dependencies:
+   ```bash
+   ./setup.sh
+   ```
+
+The script will:
+- Verify that `python3.12` is available
+- Create a virtual environment named `venv`
+- Upgrade `pip` inside the environment
+- Install packages listed in `requirements.txt`
+
+## Activating the Environment
+After setup, activate the environment whenever you work on the project:
+```bash
+source venv/bin/activate
+```
+
+When finished, deactivate it with:
+```bash
+deactivate
+```
+
+## Updating Dependencies
+If you add or update packages:
+1. Modify `requirements.txt` accordingly.
+2. Re-run `./setup.sh` to install the new dependencies.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+numpy
+pandas
+matplotlib
+scipy
+h5py
+pyhdf
+tqdm
+opencv-python
+joblib
+ipywidgets

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="python3.12"
+VENV_DIR="venv"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "Error: $PYTHON_BIN is not available on this system." >&2
+  exit 1
+fi
+
+if [ -d "$VENV_DIR" ]; then
+  echo "Virtual environment '$VENV_DIR' already exists. Skipping creation."
+else
+  echo "Creating virtual environment '$VENV_DIR' with $PYTHON_BIN..."
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+# Activate the virtual environment and install requirements
+source "$VENV_DIR/bin/activate"
+
+python --version
+pip install --upgrade pip
+
+if [ -f "requirements.txt" ]; then
+  echo "Installing Python dependencies from requirements.txt..."
+  pip install -r requirements.txt
+else
+  echo "Warning: requirements.txt not found. Skipping dependency installation." >&2
+fi
+
+deactivate
+
+echo "Setup complete. Virtual environment available at '$VENV_DIR'."


### PR DESCRIPTION
## Summary
- add a setup script that provisions a Python 3.12 virtual environment and installs dependencies
- document the environment setup workflow and activation steps in a new README
- capture the project dependencies in a requirements.txt file

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dbc0c16da08328ad9b0d2b74017a08