### PR TITLE
Add tracked scaffolding for data and figure directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,22 @@ build/
 
 # Ignore Jupyter notebook checkpoints
 .ipynb_checkpoints/
+
+# Data directories (track structure with .gitkeep files only)
+/data/*
+!/data/
+!/data/.gitkeep
+/data/raw/*
+!/data/raw/
+!/data/raw/.gitkeep
+/data/intermediate/*
+!/data/intermediate/
+!/data/intermediate/.gitkeep
+/data/finished/*
+!/data/finished/
+!/data/finished/.gitkeep
+
+# Figure directory (track structure with .gitkeep files only)
+/figure/*
+!/figure/
+!/figure/.gitkeep

--- a/data/.gitkeep
+++ b/data/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain tracked directory structure

--- a/data/finished/.gitkeep
+++ b/data/finished/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain tracked directory structure

--- a/data/intermediate/.gitkeep
+++ b/data/intermediate/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain tracked directory structure

--- a/data/raw/.gitkeep
+++ b/data/raw/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain tracked directory structure

--- a/figure/.gitkeep
+++ b/figure/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain tracked directory structure


### PR DESCRIPTION
## Summary
- create placeholder directories for raw, intermediate, and finished data as well as figures
- update the root .gitignore to retain the directory structure via .gitkeep files while ignoring generated contents

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbcc066c308328bb2eeaf3bf43136e