### PR TITLE
Relax setup script Python version requirement

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PYTHON_BIN="python3.12"
+PYTHON_BIN=${PYTHON_BIN:-python3}
 VENV_DIR="venv"
 
 if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- default the setup script to use the available `python3` interpreter instead of requiring Python 3.12

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe029a5d88328a0398b1dc7485ec7