### PR TITLE
Lint scripts and reinforce NDVI analysis workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ build/
 /figure/*
 !/figure/
 !/figure/.gitkeep
+!/figure/README.md

--- a/figure/README.md
+++ b/figure/README.md
@@ -1,0 +1,9 @@
+# Figure Output Guidelines
+
+Each analysis script should save its figures inside the `figure/` directory using the following conventions:
+
+- Create or reuse a sub-directory named after the script's filename without the extension (for example, `figure/1.03-fit-gaussia_to_ndvi`).
+- Save each image with the pattern `<script-stem>__<descriptive-name>.png` so the producing script can be identified immediately. The descriptive portion should be short, lowercase, and use hyphens or underscores instead of spaces (for example, `1.03-fit-gaussia_to_ndvi__lat60p0_lon16p0_gaussian_fit.png`).
+- When multiple figures are produced for a single script run, incrementally vary the descriptive part to make each file unique.
+
+Following this layout keeps figures organized and makes it clear which script generated each asset.

--- a/src/0.01-explore-ndvi.py
+++ b/src/0.01-explore-ndvi.py
@@ -11,7 +11,9 @@ from pyhdf.SD import SD, SDC
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-FILE_PATH = PROJECT_ROOT / "data" / "raw" / "NDVI" / "MOD13C1.A2009241.061.2021141172023.hdf"
+FILE_PATH = (
+    PROJECT_ROOT / "data" / "raw" / "NDVI" / "MOD13C1.A2009241.061.2021141172023.hdf"
+)
 
 
 def figure_directory() -> Path:
@@ -91,4 +93,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/src/0.02-apply-quality-andsave-as-stack.py
+++ b/src/0.02-apply-quality-andsave-as-stack.py
@@ -24,7 +24,9 @@ def discover_files() -> list[Path]:
 
     files = sorted(Path(path) for path in glob.glob(str(DATA_PATH / "MOD13C1.A*.hdf")))
     if not files:
-        raise FileNotFoundError(f"No HDF files matching MOD13C1 pattern found in {DATA_PATH}")
+        raise FileNotFoundError(
+            f"No HDF files matching MOD13C1 pattern found in {DATA_PATH}"
+        )
 
     print(f"Discovered {len(files)} files in {DATA_PATH}")
     return files

--- a/src/0.02-create_NDVI_mp4.py
+++ b/src/0.02-create_NDVI_mp4.py
@@ -98,6 +98,8 @@ def create_video(frames_dir: Path, output_path: Path, fps: int = 10) -> None:
     video_writer.release()
     cv2.destroyAllWindows()
     print(f"Video saved at {output_path}")
+
+
 def generate_frames(num_timesteps: int) -> None:
     """Generate frames for all available time steps using multiprocessing."""
 

--- a/src/0.03-plot-NDVI-timeseries.py
+++ b/src/0.03-plot-NDVI-timeseries.py
@@ -25,7 +25,9 @@ def lat_lon_to_indices(lat: float, lon: float) -> tuple[int, int]:
     return row_idx, col_idx
 
 
-def get_ndvi_timeseries(lat: float, lon: float) -> tuple[list[pd.Timestamp], np.ndarray]:
+def get_ndvi_timeseries(
+    lat: float, lon: float
+) -> tuple[list[pd.Timestamp], np.ndarray]:
     """Extract NDVI values and corresponding timestamps for a location."""
 
     row_idx, col_idx = lat_lon_to_indices(lat, lon)
@@ -37,7 +39,9 @@ def get_ndvi_timeseries(lat: float, lon: float) -> tuple[list[pd.Timestamp], np.
     valid_mask = ~np.isnan(ndvi_timeseries)
     ndvi_timeseries = ndvi_timeseries[valid_mask]
     valid_dates = metadata[valid_mask]
-    dates = [pd.to_datetime(f"{year}-{doy:03d}", format="%Y-%j") for year, doy in valid_dates]
+    dates = [
+        pd.to_datetime(f"{year}-{doy:03d}", format="%Y-%j") for year, doy in valid_dates
+    ]
 
     print(f"Loaded {len(dates)} observations for ({lat}°, {lon}°)")
     return dates, ndvi_timeseries
@@ -49,7 +53,9 @@ def plot_ndvi(lat: float, lon: float) -> Path:
     dates, ndvi_timeseries = get_ndvi_timeseries(lat, lon)
 
     fig, ax = plt.subplots(figsize=(12, 5))
-    ax.plot(dates, ndvi_timeseries, marker="o", linestyle="-", color="green", label="NDVI")
+    ax.plot(
+        dates, ndvi_timeseries, marker="o", linestyle="-", color="green", label="NDVI"
+    )
     ax.set_xlabel("Date")
     ax.set_ylabel("NDVI")
     ax.set_title(f"NDVI Time Series at ({lat}°N, {lon}°E)")

--- a/src/0.04-cleanup-time-series.py
+++ b/src/0.04-cleanup-time-series.py
@@ -28,19 +28,25 @@ def lat_lon_to_indices(lat: float, lon: float) -> tuple[int, int]:
     return row_idx, col_idx
 
 
-def get_ndvi_timeseries(lat: float, lon: float) -> tuple[list[pd.Timestamp], np.ndarray]:
+def get_ndvi_timeseries(
+    lat: float, lon: float
+) -> tuple[list[pd.Timestamp], np.ndarray]:
     row_idx, col_idx = lat_lon_to_indices(lat, lon)
 
     with h5py.File(HDF5_FILE, "r") as h5f:
         metadata = h5f["metadata"][:]
         ndvi_timeseries = h5f["ndvi_stack"][:, row_idx, col_idx]
 
-    dates = [pd.to_datetime(f"{year}-{doy:03d}", format="%Y-%j") for year, doy in metadata]
+    dates = [
+        pd.to_datetime(f"{year}-{doy:03d}", format="%Y-%j") for year, doy in metadata
+    ]
     print(f"Loaded {len(dates)} observations for ({lat}°, {lon}°)")
     return dates, ndvi_timeseries
 
 
-def process_ndvi(dates: list[pd.Timestamp], ndvi_timeseries: np.ndarray) -> tuple[float, np.ndarray, np.ndarray]:
+def process_ndvi(
+    dates: list[pd.Timestamp], ndvi_timeseries: np.ndarray
+) -> tuple[float, np.ndarray, np.ndarray]:
     winter_ndvi = float(np.nanquantile(ndvi_timeseries, 0.025))
     corrected_ndvi = np.copy(ndvi_timeseries)
     corrected_ndvi[ndvi_timeseries < winter_ndvi] = winter_ndvi
@@ -59,10 +65,37 @@ def plot_ndvi(lat: float, lon: float) -> Path:
     winter_ndvi, corrected_ndvi, filtered_ndvi = process_ndvi(dates, ndvi_timeseries)
 
     fig, ax = plt.subplots(figsize=(12, 6))
-    ax.plot(dates, ndvi_timeseries, marker="o", linestyle="-", color="gray", alpha=0.6, label="Raw NDVI")
-    ax.axhline(y=winter_ndvi, color="blue", linestyle="--", label=f"Winter NDVI ({winter_ndvi:.3f})")
-    ax.plot(dates, corrected_ndvi, marker="o", linestyle="-", color="green", label="Corrected NDVI")
-    ax.plot(dates, filtered_ndvi, marker="o", linestyle="-", color="red", label="Filtered NDVI (Moving Median)")
+    ax.plot(
+        dates,
+        ndvi_timeseries,
+        marker="o",
+        linestyle="-",
+        color="gray",
+        alpha=0.6,
+        label="Raw NDVI",
+    )
+    ax.axhline(
+        y=winter_ndvi,
+        color="blue",
+        linestyle="--",
+        label=f"Winter NDVI ({winter_ndvi:.3f})",
+    )
+    ax.plot(
+        dates,
+        corrected_ndvi,
+        marker="o",
+        linestyle="-",
+        color="green",
+        label="Corrected NDVI",
+    )
+    ax.plot(
+        dates,
+        filtered_ndvi,
+        marker="o",
+        linestyle="-",
+        color="red",
+        label="Filtered NDVI (Moving Median)",
+    )
     ax.set_xlabel("Date")
     ax.set_ylabel("NDVI")
     ax.set_title(f"NDVI Time Series at ({lat}°N, {lon}°E)")
@@ -71,7 +104,9 @@ def plot_ndvi(lat: float, lon: float) -> Path:
 
     safe_lat = str(lat).replace(".", "p")
     safe_lon = str(lon).replace(".", "p")
-    output_path = SINGLE_LOCATION_DIR / f"ndvi-preprocessing-{safe_lat}N-{safe_lon}E.png"
+    output_path = (
+        SINGLE_LOCATION_DIR / f"ndvi-preprocessing-{safe_lat}N-{safe_lon}E.png"
+    )
     fig.savefig(output_path, dpi=300, bbox_inches="tight")
     plt.close(fig)
     print(f"Saved preprocessing figure to {output_path}")
@@ -79,7 +114,9 @@ def plot_ndvi(lat: float, lon: float) -> Path:
     return output_path
 
 
-def compare_yearly_ndvi(lat: float, lon: float, year_start: int = 2002, year_end: int = 2010) -> Path:
+def compare_yearly_ndvi(
+    lat: float, lon: float, year_start: int = 2002, year_end: int = 2010
+) -> Path:
     dates, ndvi_timeseries = get_ndvi_timeseries(lat, lon)
     _, _, filtered_ndvi = process_ndvi(dates, ndvi_timeseries)
 
@@ -87,13 +124,17 @@ def compare_yearly_ndvi(lat: float, lon: float, year_start: int = 2002, year_end
     for i, date in enumerate(dates):
         year, doy = date.year, date.day_of_year
         if year_start <= year <= year_end:
-            ndvi_by_year.setdefault(year, np.full(366, np.nan))[doy - 1] = filtered_ndvi[i]
+            ndvi_by_year.setdefault(year, np.full(366, np.nan))[doy - 1] = (
+                filtered_ndvi[i]
+            )
 
     fig, ax = plt.subplots(figsize=(12, 6))
     for year, ndvi_values in sorted(ndvi_by_year.items()):
         mask = ~np.isnan(ndvi_values)
         if np.any(mask):
-            ax.plot(np.arange(1, 367)[mask], ndvi_values[mask], label=str(year), alpha=0.7)
+            ax.plot(
+                np.arange(1, 367)[mask], ndvi_values[mask], label=str(year), alpha=0.7
+            )
 
     ax.set_xlabel("Day of Year")
     ax.set_ylabel("NDVI")
@@ -103,7 +144,10 @@ def compare_yearly_ndvi(lat: float, lon: float, year_start: int = 2002, year_end
 
     safe_lat = str(lat).replace(".", "p")
     safe_lon = str(lon).replace(".", "p")
-    output_path = COMPARISON_DIR / f"ndvi-comparison-{safe_lat}N-{safe_lon}E-{year_start}-{year_end}.png"
+    output_path = (
+        COMPARISON_DIR
+        / f"ndvi-comparison-{safe_lat}N-{safe_lon}E-{year_start}-{year_end}.png"
+    )
     fig.savefig(output_path, dpi=300, bbox_inches="tight")
     plt.close(fig)
     print(f"Saved yearly comparison figure to {output_path}")

--- a/src/0.052-compare-seasonal-curve-fits.py
+++ b/src/0.052-compare-seasonal-curve-fits.py
@@ -4,6 +4,7 @@ The notebook version of this file relied on inline plotting.  This script fits
 multiple analytic curves, prints the fitted parameters, and saves the resulting
 figures to ``figure/0.052-compare-seasonal-curve-fits``.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -89,7 +90,9 @@ def double_logistic(
     return bias + scale * (spring - autumn)
 
 
-def tanh_sine(t: np.ndarray, phase: float, bias: float, scale: float, sharpness: float) -> np.ndarray:
+def tanh_sine(
+    t: np.ndarray, phase: float, bias: float, scale: float, sharpness: float
+) -> np.ndarray:
     angle = (t - phase) * 2.0 * np.pi / 365.0
     numerator = np.tanh(np.sin(angle) * sharpness)
     denominator = np.tanh(sharpness) if sharpness != 0 else 1.0
@@ -111,7 +114,9 @@ def plot_fit(
 ) -> Path:
     fig, ax = plt.subplots(figsize=(10, 5))
     ax.scatter(doy, ndvi, color="black", label="Observed NDVI", zorder=2)
-    ax.plot(x_dense, y_dense, color="red", linestyle="--", label="Fitted curve", zorder=1)
+    ax.plot(
+        x_dense, y_dense, color="red", linestyle="--", label="Fitted curve", zorder=1
+    )
     ax.set_xlabel("Day of Year")
     ax.set_ylabel("NDVI")
     ax.set_title(title)
@@ -186,7 +191,9 @@ if __name__ == "__main__":
     y_demo = sigmoid_sine(x_demo, true_a, true_k) + 0.1 * rng.normal(size=len(x_demo))
 
     demo_guess = [1.0, 1.0]
-    demo_params, _ = curve_fit(sigmoid_sine, x_demo, y_demo, p0=demo_guess, maxfev=20000)
+    demo_params, _ = curve_fit(
+        sigmoid_sine, x_demo, y_demo, p0=demo_guess, maxfev=20000
+    )
     print("Sigmoid-sine recovered parameters:")
     print(f"  amplitude: true={true_a:.2f}, fitted={demo_params[0]:.3f}")
     print(f"  steepness: true={true_k:.2f}, fitted={demo_params[1]:.3f}")

--- a/src/0.07-explore-fitparams.py
+++ b/src/0.07-explore-fitparams.py
@@ -9,7 +9,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 FILE_PATH = Path("/work/pschluet/green_wave/data/intermediate/ndvi_fit_params.npz")
-CLEANED_OUTPUT_PATH = Path("/work/pschluet/green_wave/data/intermediate/ndvi_fit_params_cleaned.npz")
+CLEANED_OUTPUT_PATH = Path(
+    "/work/pschluet/green_wave/data/intermediate/ndvi_fit_params_cleaned.npz"
+)
 FIGURE_ROOT = Path(__file__).resolve().parents[1] / "figure" / Path(__file__).stem
 MAP_DIR = FIGURE_ROOT / "maps"
 PROFILE_DIR = FIGURE_ROOT / "profiles"
@@ -23,7 +25,9 @@ PARAM_NAMES = ["xmidSNDVI", "scalSNDVI", "xmidANDVI", "scalANDVI", "bias", "scal
 def load_parameters() -> np.ndarray:
     data = np.load(FILE_PATH)
     ndvi_fit_params = data["ndvi_fit_all"]
-    print(f"Loaded NDVI fit parameters with shape {ndvi_fit_params.shape} from {FILE_PATH}")
+    print(
+        f"Loaded NDVI fit parameters with shape {ndvi_fit_params.shape} from {FILE_PATH}"
+    )
     return ndvi_fit_params
 
 
@@ -31,8 +35,10 @@ def summarise_parameters(ndvi_fit_params: np.ndarray, title: str) -> None:
     print(f"\nParameter summary: {title}")
     for i, param in enumerate(PARAM_NAMES):
         param_data = ndvi_fit_params[:, :, i]
-        print(f"  {param} -> min {np.nanmin(param_data):.2f}, max {np.nanmax(param_data):.2f}, "
-              f"mean {np.nanmean(param_data):.2f}, median {np.nanmedian(param_data):.2f}, std {np.nanstd(param_data):.2f}")
+        print(
+            f"  {param} -> min {np.nanmin(param_data):.2f}, max {np.nanmax(param_data):.2f}, "
+            f"mean {np.nanmean(param_data):.2f}, median {np.nanmedian(param_data):.2f}, std {np.nanstd(param_data):.2f}"
+        )
 
 
 def apply_constraints(ndvi_fit_params: np.ndarray) -> np.ndarray:
@@ -48,15 +54,21 @@ def apply_constraints(ndvi_fit_params: np.ndarray) -> np.ndarray:
     for idx, (lower, upper) in constraints.items():
         original_invalid = np.count_nonzero(~np.isnan(ndvi_fit_params[:, :, idx]))
         param_data = ndvi_fit_params[:, :, idx]
-        param_data = np.where((param_data >= lower) & (param_data <= upper), param_data, np.nan)
+        param_data = np.where(
+            (param_data >= lower) & (param_data <= upper), param_data, np.nan
+        )
         ndvi_fit_params[:, :, idx] = param_data
         remaining = np.count_nonzero(~np.isnan(param_data))
-        print(f"Applied bounds {lower}-{upper} to {PARAM_NAMES[idx]}: kept {remaining} / {original_invalid} values")
+        print(
+            f"Applied bounds {lower}-{upper} to {PARAM_NAMES[idx]}: kept {remaining} / {original_invalid} values"
+        )
 
     return ndvi_fit_params
 
 
-def plot_param_map(ndvi_fit_params: np.ndarray, param_idx: int, title: str, cmap: str = "viridis") -> Path:
+def plot_param_map(
+    ndvi_fit_params: np.ndarray, param_idx: int, title: str, cmap: str = "viridis"
+) -> Path:
     param_data = ndvi_fit_params[:, :, param_idx]
 
     fig, ax = plt.subplots(figsize=(10, 6))

--- a/src/0.08-explore-doublre-regression-function.py
+++ b/src/0.08-explore-doublre-regression-function.py
@@ -12,7 +12,15 @@ FIGURE_DIR = Path(__file__).resolve().parents[1] / "figure" / Path(__file__).ste
 FIGURE_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def double_logistic(t: np.ndarray, xmidSNDVI: float, scalSNDVI: float, xmidANDVI: float, scalANDVI: float, bias: float, scale: float) -> np.ndarray:
+def double_logistic(
+    t: np.ndarray,
+    xmidSNDVI: float,
+    scalSNDVI: float,
+    xmidANDVI: float,
+    scalANDVI: float,
+    bias: float,
+    scale: float,
+) -> np.ndarray:
     spring = 1 / (1 + np.exp((xmidSNDVI - t) / scalSNDVI))
     autumn = 1 / (1 + np.exp((xmidANDVI - t) / scalANDVI))
     return bias + scale * (spring - autumn)

--- a/src/0.083-explore-warped-sine.py
+++ b/src/0.083-explore-warped-sine.py
@@ -1,4 +1,5 @@
 """Visualise warped sine constructions without relying on notebook widgets."""
+
 from __future__ import annotations
 
 from itertools import product
@@ -46,7 +47,6 @@ def plot_phase_modulation() -> Path:
 
     fig, axes = plt.subplots(2, 2, figsize=(10, 8), sharex=True, sharey=True)
     for ax, (power, phase_shift) in zip(axes.flat, configs):
-        warped = g(x, period, power) * period
         y = np.sin(2 * np.pi * x + power * np.sin(2 * np.pi * (x - phase_shift)))
         ax.plot(x, y)
         ax.set_title(f"p={power}, phase shift={phase_shift}")
@@ -71,11 +71,14 @@ def plot_sigmoid_modulation() -> Path:
     p_values = [0.25, 0.5, 0.75]
     offsets = [-1.0, 0.0, 1.0]
 
-    fig, axes = plt.subplots(len(p_values), len(offsets), figsize=(12, 8), sharex=True, sharey=True)
+    fig, axes = plt.subplots(
+        len(p_values), len(offsets), figsize=(12, 8), sharex=True, sharey=True
+    )
     for (i, power), (j, offset) in product(enumerate(p_values), enumerate(offsets)):
         ax = axes[i, j]
-        warped = g(x, period, power) * period
-        y = sigmoid(np.sin(2 * np.pi * x + power * np.sin(2 * np.pi * (x - 0.25))) * 5 + offset)
+        y = sigmoid(
+            np.sin(2 * np.pi * x + power * np.sin(2 * np.pi * (x - 0.25))) * 5 + offset
+        )
         ax.plot(x, y)
         ax.set_title(f"p={power}, offset={offset}")
         ax.grid(True, linestyle=":", linewidth=0.5)

--- a/src/0.09-fit-cyclic-gaussian.py
+++ b/src/0.09-fit-cyclic-gaussian.py
@@ -1,4 +1,5 @@
 """Fit cyclic Gaussian curves to an NDVI stack stored in HDF5 format."""
+
 from __future__ import annotations
 
 import argparse
@@ -93,11 +94,18 @@ def fit_stack(
 
             x = doy[mask]
             y = filtered[mask]
-            initial_guess = [np.nanmax(y) - np.nanmin(y), x[np.argmax(y)], 30.0, np.nanmin(y)]
+            initial_guess = [
+                np.nanmax(y) - np.nanmin(y),
+                x[np.argmax(y)],
+                30.0,
+                np.nanmin(y),
+            ]
             bounds = ([0, 0, 0, -np.inf], [np.inf, 365, 365, np.inf])
 
             try:
-                popt, _ = curve_fit(gaussian_cyclic, x, y, p0=initial_guess, bounds=bounds)
+                popt, _ = curve_fit(
+                    gaussian_cyclic, x, y, p0=initial_guess, bounds=bounds
+                )
             except RuntimeError:
                 continue
 
@@ -116,12 +124,16 @@ def fit_stack(
     return maps
 
 
-def save_maps(output_path: Path, maps: dict[str, np.ndarray], metadata: np.ndarray) -> None:
+def save_maps(
+    output_path: Path, maps: dict[str, np.ndarray], metadata: np.ndarray
+) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with h5py.File(output_path, "w") as dst:
         for key, array in maps.items():
             dst.create_dataset(key, data=array, dtype="f4", compression="lzf")
-        dst.create_dataset("metadata", data=metadata, dtype=metadata.dtype, compression="lzf")
+        dst.create_dataset(
+            "metadata", data=metadata, dtype=metadata.dtype, compression="lzf"
+        )
 
 
 def main() -> None:

--- a/src/0.10-render-ndvi-irg-frames.py
+++ b/src/0.10-render-ndvi-irg-frames.py
@@ -4,6 +4,7 @@ This script replaces its original notebook export. It loads the fitted NDVI
 parameters, prints basic diagnostics, and saves predicted NDVI as well as IRG
 frames to dedicated sub-directories within ``figure/``.
 """
+
 from __future__ import annotations
 
 import argparse

--- a/src/1.01-fit-double-logistic-wrap.py
+++ b/src/1.01-fit-double-logistic-wrap.py
@@ -1,376 +1,335 @@
-#!/usr/bin/env python
-# coding: utf-8
+#!/usr/bin/env python3
+"""Inspect and fit sigmoid double sawtooth models to NDVI time series."""
 
-# In[1]:
+from __future__ import annotations
 
+from pathlib import Path
+from typing import Iterable, Tuple
 
-import os
 import h5py
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 from scipy.ndimage import median_filter
 from scipy.optimize import curve_fit
 
 
-# In[2]:
-
-
-from pathlib import Path
-
-# Path to HDF5 file
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-hdf5_file = PROJECT_ROOT / "data" / "intermediate" / "ndvi_stack_optimized.h5"
+DATA_PATH = PROJECT_ROOT / "data" / "intermediate" / "ndvi_stack_optimized.h5"
+FIGURE_ROOT = PROJECT_ROOT / "figure"
+SCRIPT_STEM = Path(__file__).stem
+SCRIPT_FIGURE_DIR = FIGURE_ROOT / SCRIPT_STEM
+SCRIPT_FIGURE_DIR.mkdir(parents=True, exist_ok=True)
 
 
-# In[3]:
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+def _slugify(text: str) -> str:
+    return (
+        text.replace("+", "p")
+        .replace("-", "m")
+        .replace(" ", "_")
+        .replace("/", "-")
+        .replace(".", "p")
+    )
 
 
-# -------------------------------
-# Function to extract NDVI time series for a given lat/lon
-# -------------------------------
-def get_ndvi_timeseries(lat, lon):
-    """Extract NDVI time series from HDF5 for a given latitude & longitude."""
-    
-    # Convert latitude & longitude to row/column indices
-    row_idx = int((90 - lat) / 0.05)  # Convert latitude to row
-    col_idx = int((lon + 180) / 0.05)  # Convert longitude to column
+def _save_figure(fig: plt.Figure, description: str) -> Path:
+    filename = f"{SCRIPT_STEM}__{_slugify(description)}.png"
+    path = SCRIPT_FIGURE_DIR / filename
+    fig.savefig(path, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved figure to {path}")
+    return path
+
+
+def _coordinate_tag(lat: float, lon: float) -> str:
+    return _slugify(f"lat{lat:.1f}_lon{lon:.1f}")
+
+
+# ---------------------------------------------------------------------------
+# Data access and preparation
+# ---------------------------------------------------------------------------
+def get_ndvi_timeseries(
+    lat: float, lon: float
+) -> Tuple[list[pd.Timestamp], np.ndarray]:
+    """Extract NDVI time series from the HDF5 stack for a location."""
+
+    if not DATA_PATH.exists():
+        raise FileNotFoundError(f"NDVI stack not found at {DATA_PATH}")
+
+    row_idx = int((90 - lat) / 0.05)
+    col_idx = int((lon + 180) / 0.05)
     print(f"Nearest pixel index: row={row_idx}, col={col_idx}")
 
-    # Open HDF5 file and read metadata and NDVI time series
-    with h5py.File(hdf5_file, "r") as h5f:
-        metadata = h5f["metadata"][:]  # Load (year, doy)
-        ndvi_timeseries = h5f["ndvi_stack"][:, row_idx, col_idx]  # Load only the required pixel
+    with h5py.File(DATA_PATH, "r") as h5f:
+        metadata = h5f["metadata"][:]
+        ndvi_timeseries = h5f["ndvi_stack"][:, row_idx, col_idx]
 
-    # Convert metadata (year, DOY) to actual dates
-    dates = [pd.to_datetime(f"{year}-{doy:03d}", format="%Y-%j") for year, doy in metadata]
-
+    dates = [
+        pd.to_datetime(f"{year}-{doy:03d}", format="%Y-%j") for year, doy in metadata
+    ]
     return dates, ndvi_timeseries
 
 
-# In[4]:
+def process_ndvi(dates: Iterable[pd.Timestamp], ndvi_timeseries: np.ndarray) -> tuple:
+    """Apply winter correction and a moving median filter to the NDVI data."""
 
-
-# -------------------------------
-# Function to process NDVI time series
-# -------------------------------
-def process_ndvi(dates, ndvi_timeseries):
-    """Apply winter correction and moving median filter to NDVI time series."""
-
-    # Compute 2.5% quantile (winter baseline)
     winter_ndvi = np.nanquantile(ndvi_timeseries, 0.025)
-
-    # Apply winter NDVI correction (clip values below threshold)
     corrected_ndvi = np.copy(ndvi_timeseries)
     corrected_ndvi[ndvi_timeseries < winter_ndvi] = winter_ndvi
-
-   # # Replace missing values in winter period (DOY 300-365 & 1-60)
-   # for i, date in enumerate(dates):
-   #     doy = date.day_of_year
-   #     if np.isnan(corrected_ndvi[i]) and (doy >= 300 or doy <= 60):
-   #         corrected_ndvi[i] = winter_ndvi
-
-    # Apply Moving Median Filter (window size = 3)
     filtered_ndvi = median_filter(corrected_ndvi, size=3)
-
     return winter_ndvi, corrected_ndvi, filtered_ndvi
 
 
-# In[5]:
+def plot_ndvi(lat: float, lon: float) -> None:
+    """Plot the raw, corrected, and filtered NDVI time series for a location."""
 
-
-# -------------------------------
-# Function to plot NDVI time series
-# -------------------------------
-def plot_ndvi(lat, lon):
-    """Extract, process, and plot NDVI time series for a given location."""
-    
     dates, ndvi_timeseries = get_ndvi_timeseries(lat, lon)
     winter_ndvi, corrected_ndvi, filtered_ndvi = process_ndvi(dates, ndvi_timeseries)
 
-    plt.figure(figsize=(12, 6))
+    fig, ax = plt.subplots(figsize=(12, 6))
+    ax.plot(
+        dates,
+        ndvi_timeseries,
+        marker="o",
+        linestyle="-",
+        color="gray",
+        alpha=0.6,
+        label="Raw NDVI",
+    )
+    ax.axhline(
+        y=winter_ndvi,
+        color="blue",
+        linestyle="--",
+        label=f"Winter NDVI ({winter_ndvi:.3f})",
+    )
+    ax.plot(
+        dates,
+        corrected_ndvi,
+        marker="o",
+        linestyle="-",
+        color="green",
+        label="Corrected NDVI",
+    )
+    ax.plot(
+        dates,
+        filtered_ndvi,
+        marker="o",
+        linestyle="-",
+        color="red",
+        label="Filtered NDVI",
+    )
+    ax.set_xlabel("Date")
+    ax.set_ylabel("NDVI")
+    ax.set_title(f"NDVI Time Series at ({lat}°N, {lon}°E)")
+    ax.grid(True)
+    ax.legend()
+    _save_figure(fig, f"{_coordinate_tag(lat, lon)}_timeseries")
 
-    # Raw NDVI
-    plt.plot(dates, ndvi_timeseries, marker="o", linestyle="-", color="gray", alpha=0.6, label="Raw NDVI")
 
-    # Winter NDVI baseline
-    plt.axhline(y=winter_ndvi, color="blue", linestyle="--", label=f"Winter NDVI ({winter_ndvi:.3f})")
-
-    # Corrected NDVI (baseline applied)
-    plt.plot(dates, corrected_ndvi, marker="o", linestyle="-", color="green", label="Corrected NDVI")
-
-    # Filtered NDVI
-    plt.plot(dates, filtered_ndvi, marker="o", linestyle="-", color="red", label="Filtered NDVI (Moving Median)")
-
-    plt.xlabel("Date")
-    plt.ylabel("NDVI")
-    plt.title(f"NDVI Time Series at ({lat}°N, {lon}°E)")
-    plt.legend()
-    plt.grid(True)
-    plt.show()
-
-
-# In[6]:
-
-
-plot_ndvi(60, 16)
-
-
-# In[7]:
-
-
-plot_ndvi(50, 16)
-
-
-# In[44]:
-
-
+# ---------------------------------------------------------------------------
+# Sigmoid double sawtooth implementation
+# ---------------------------------------------------------------------------
 def sigmoid_double_sawtooth(
-    t, z1, d1, z2, d2, bias, scale, period=365,return_derivative=False
+    t: np.ndarray,
+    z1: float,
+    d1: float,
+    z2: float,
+    d2: float,
+    bias: float,
+    scale: float,
+    period: float = 365,
+    return_derivative: bool = False,
 ):
-    """
-    Compute s(t) = sigmoid(double_sawtooth(t)) in one pass.
-    Optionally also return ds/dt = d/dt [sigmoid(double_sawtooth(t))].
+    """Evaluate a sigmoid wrapped double sawtooth curve."""
 
-    Parameters
-    ----------
-    t : array-like
-        Time points at which to evaluate.
-    period : float
-        The period (e.g. 365).
-    z1, d1 : float
-        Offset & slope for the increasing sawtooth (st1).
-    z2, d2 : float
-        Offset & slope for the decreasing sawtooth (st2).
-    return_derivative : bool, optional
-        If True, also return ds/dt in addition to s(t).
-
-    Returns
-    -------
-    s_values : ndarray
-        The values of sigmoid(double_sawtooth(t)).
-    ds_dt_values : ndarray (only if return_derivative=True)
-        The derivative d/dt [sigmoid(double_sawtooth(t))].
-    """
-    z1 = z1 % 365
-    z2 = z2 % 365
-    d1 = 1/d1
-    d2 = 1/d2
+    z1 = z1 % period
+    z2 = z2 % period
+    d1 = 1 / d1
+    d2 = 1 / d2
     t = np.asarray(t)
 
-    # 1) Find the two crossing times in [0, period)
     c1, c2 = _get_crossings(z1, d1, z2, d2, period)
-
-    # 2) Evaluate st1, st2 at the crossing times c1, c2 to see which is "lowest" or "highest"
     val1 = _sawtooth_zp_d(c1, period, z1, d1)
     val2 = _sawtooth_zp_d(c2, period, z1, d1)
 
-    # We'll define the piecewise intervals:
     modt = t % period
-    in_first  = (modt < c1)
+    in_first = modt < c1
     in_second = (modt >= c1) & (modt < c2)
-    # The complement is the third interval: modt >= c2
 
-    # Pre-allocate outputs
-    x_vals = np.zeros_like(t)  # double_sawtooth(t)
+    x_vals = np.zeros_like(t)
     if return_derivative:
-        xprime_vals = np.zeros_like(t)  # piecewise slope d1 or d2
+        xprime_vals = np.zeros_like(t)
 
-    # 3) Fill in piecewise segments
-    # If val1 < val2 => c1 is 'lowest crossing', c2 is 'highest crossing',
-    # => st1 used on [c1,c2), st2 on [0,c1) & [c2,P).
-    # Otherwise st2 used on [c1,c2), st1 on outside.
     if val1 < val2:
-        # st2 in [0,c1) and [c2,P), st1 in [c1,c2)
-        x_vals[in_first]  = _sawtooth_zp_d(t[in_first],  period, z2, d2)
+        x_vals[in_first] = _sawtooth_zp_d(t[in_first], period, z2, d2)
         x_vals[in_second] = _sawtooth_zp_d(t[in_second], period, z1, d1)
-        x_vals[~(in_first | in_second)] = _sawtooth_zp_d(t[~(in_first | in_second)], period, z2, d2)
-
+        x_vals[~(in_first | in_second)] = _sawtooth_zp_d(
+            t[~(in_first | in_second)], period, z2, d2
+        )
         if return_derivative:
-            xprime_vals[in_first]  = d2
+            xprime_vals[in_first] = d2
             xprime_vals[in_second] = d1
             xprime_vals[~(in_first | in_second)] = d2
     else:
-        # st1 in [0,c1) and [c2,P), st2 in [c1,c2)
-        x_vals[in_first]  = _sawtooth_zp_d(t[in_first],  period, z1, d1)
+        x_vals[in_first] = _sawtooth_zp_d(t[in_first], period, z1, d1)
         x_vals[in_second] = _sawtooth_zp_d(t[in_second], period, z2, d2)
-        x_vals[~(in_first | in_second)] = _sawtooth_zp_d(t[~(in_first | in_second)], period, z1, d1)
-
+        x_vals[~(in_first | in_second)] = _sawtooth_zp_d(
+            t[~(in_first | in_second)], period, z1, d1
+        )
         if return_derivative:
-            xprime_vals[in_first]  = d1
+            xprime_vals[in_first] = d1
             xprime_vals[in_second] = d2
             xprime_vals[~(in_first | in_second)] = d1
 
-    # 4) Sigmoid
     s_vals = _logistic(x_vals)
 
     if return_derivative:
-        # dsigma/dx = s * (1 - s)
         dsigma_dx = s_vals * (1 - s_vals)
-        # By chain rule: d/dt [sigma(x(t))] = dsigma/dx * dx/dt
         ds_dt = dsigma_dx * xprime_vals
-        return s_vals*scale+bias, ds_dt*scale
+        return s_vals * scale + bias, ds_dt * scale
 
-    else:
-        # Just return the sigmoid
-        return s_vals*scale+bias
+    return s_vals * scale + bias
 
 
-# --- Small helpers (underscored to show they are "private") ---
-def _sawtooth_zp_d(tt, period, z, d):
-    """Compute the standard sawtooth at times tt, with offset z, slope d."""
-    return (((tt - z - period/2) % period) - period/2) * d
+def _sawtooth_zp_d(tt: np.ndarray, period: float, z: float, d: float) -> np.ndarray:
+    return (((tt - z - period / 2) % period) - period / 2) * d
 
-def _logistic(x):
-    """Sigmoid."""
+
+def _logistic(x: np.ndarray) -> np.ndarray:
     return 1 / (1 + np.exp(-x))
 
-def _get_crossings(z1, d1, z2, d2, period=365):
-    """
-    Return the two crossing times c1, c2 in ascending order.
-    If fewer than 2, just pick c1=0, c2=period/2 to avoid errors.
-    """
+
+def _get_crossings(
+    z1: float, d1: float, z2: float, d2: float, period: float = 365
+) -> tuple:
     crossings = _find_sawtooth_intersections(z1, d1, z2, d2, period)
     if len(crossings) < 2:
-        return (0.0, period / 2)
+        return 0.0, period / 2
     return crossings[0], crossings[1]
 
-def _find_sawtooth_intersections(z1, d1, z2, d2, period=365):
-    """Analytic intersection solver, same logic as before."""
+
+def _find_sawtooth_intersections(
+    z1: float, d1: float, z2: float, d2: float, period: float = 365
+) -> list:
     z1_mod = z1 % period
     z2_mod = z2 % period
 
     r = d2 / d1
     dprime = (z1_mod - z2_mod) % period
 
-    # T1
-    num1 = r*dprime + (period/2)*(1 - r)
-    den = (1 - r)
+    num1 = r * dprime + (period / 2) * (1 - r)
+    den = 1 - r
     T1 = num1 / den
 
-    # T2
-    num2 = r*dprime + (period/2)*(1 - 3*r)
+    num2 = r * dprime + (period / 2) * (1 - 3 * r)
     T2 = num2 / den
 
-    solutions = []
+    solutions: list[float] = []
     if 0 <= T1 < (period - dprime):
-        c1 = (z1_mod + (period/2) + T1) % period
+        c1 = (z1_mod + (period / 2) + T1) % period
         solutions.append(c1)
     if (period - dprime) <= T2 < period:
-        c2 = (z1_mod + (period/2) + T2) % period
+        c2 = (z1_mod + (period / 2) + T2) % period
         solutions.append(c2)
 
     solutions.sort()
     return solutions
 
 
-# In[62]:
+# ---------------------------------------------------------------------------
+# Model fitting
+# ---------------------------------------------------------------------------
+def fit_sigmoid_double_sawtooth(lat: float, lon: float) -> np.ndarray | None:
+    """Fit the sigmoid-double-sawtooth model and plot the result."""
 
-
-# -------------------------------
-# Function to fit sigmoid_double_sawtooth to NDVI data
-# -------------------------------
-def fit_sigmoid_double_sawtooth(lat, lon):
-    """Fit sigmoid_double_sawtooth function to NDVI time series at given location."""
-    
-    # Extract and process NDVI data
     dates, ndvi_timeseries = get_ndvi_timeseries(lat, lon)
-    winter_ndvi, corrected_ndvi, filtered_ndvi = process_ndvi(dates, ndvi_timeseries)
+    _, _, filtered_ndvi = process_ndvi(dates, ndvi_timeseries)
 
-    # Convert dates to numeric values (days of year)
     doy = np.array([date.day_of_year for date in dates])
-
-    # Initial parameter guesses: (z1, d1, z2, d2, bias, scale)
-    
-    
-
-
-    # Interpolate NaN values
     valid_mask = ~np.isnan(filtered_ndvi) & ~np.isinf(filtered_ndvi)
     doy_valid = doy[valid_mask]
     ndvi_valid = filtered_ndvi[valid_mask]
-    
-    initial_guess = [100, 50, 250, -50, np.mean(ndvi_valid), np.ptp(ndvi_valid)]
 
-    # Fit the model
-    try:
-        params, _ = curve_fit(
-            sigmoid_double_sawtooth, doy_valid, ndvi_valid,
-            p0=initial_guess, bounds=([-np.inf, 0, -np.inf, -np.inf, -np.inf, 0.00001], [np.inf, np.inf, np.inf, 0, np.inf, np.inf])
-        )
-        print("Optimized Parameters:", params)
-    except RuntimeError as e:
-        print("Fit failed:", e)
+    if doy_valid.size == 0:
+        print("No valid NDVI observations available for fitting.")
         return None
 
-    # Plot results
-    plt.figure(figsize=(12, 6))
-    plt.scatter(doy, filtered_ndvi, label="Filtered NDVI", color="red", alpha=0.6)
+    initial_guess = [
+        100,
+        50,
+        250,
+        -50,
+        float(np.mean(ndvi_valid)),
+        float(np.ptp(ndvi_valid)),
+    ]
+
+    try:
+        params, _ = curve_fit(
+            sigmoid_double_sawtooth,
+            doy_valid,
+            ndvi_valid,
+            p0=initial_guess,
+            bounds=(
+                [-np.inf, 0, -np.inf, -np.inf, -np.inf, 1e-5],
+                [np.inf, np.inf, np.inf, 0, np.inf, np.inf],
+            ),
+        )
+    except RuntimeError as exc:
+        print(f"Fit failed: {exc}")
+        return None
+
+    print(
+        "Optimized Parameters:",
+        {
+            "z1": params[0],
+            "d1": params[1],
+            "z2": params[2],
+            "d2": params[3],
+            "bias": params[4],
+            "scale": params[5],
+        },
+    )
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+    ax.scatter(doy, filtered_ndvi, label="Filtered NDVI", color="red", alpha=0.6)
     t_fit = np.linspace(1, 365, 1000)
-    plt.plot(t_fit, sigmoid_double_sawtooth(t_fit, *params), label="Fitted Curve", color="blue")
-    plt.xlabel("Day of Year")
-    plt.ylabel("NDVI")
-    plt.title(f"NDVI Fit at ({lat}°N, {lon}°E)")
-    plt.legend()
-    plt.grid(True)
-    plt.show()
+    ax.plot(
+        t_fit,
+        sigmoid_double_sawtooth(t_fit, *params),
+        label="Fitted Curve",
+        color="blue",
+    )
+    ax.set_xlabel("Day of Year")
+    ax.set_ylabel("NDVI")
+    ax.set_title(f"Sigmoid Double Sawtooth Fit at ({lat}°N, {lon}°E)")
+    ax.legend()
+    ax.grid(True)
+    _save_figure(fig, f"{_coordinate_tag(lat, lon)}_fit")
 
     return params
 
-# Example usage
-fit_params = fit_sigmoid_double_sawtooth(60, 16)
+
+def main() -> None:
+    coordinates = [
+        (60, 16),
+        (50, 16),
+        (61, 16),
+        (59, 16),
+        (60, 15),
+        (40, 16),
+        (30, 16),
+        (20, 16),
+        (-33, 27),
+    ]
+
+    for lat, lon in coordinates:
+        print(f"\nProcessing location ({lat}°N, {lon}°E)")
+        plot_ndvi(lat, lon)
+        fit_sigmoid_double_sawtooth(lat, lon)
 
 
-# In[63]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(61, 16)
-
-
-# In[64]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(59, 16)
-
-
-# In[65]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(60, 15)
-
-
-# In[66]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(50, 16)
-
-
-# In[67]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(40, 16)
-
-
-# In[68]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(30, 16)
-
-
-# In[69]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(20, 16)
-
-
-# In[70]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(-33, 27)
-
-
-# In[ ]:
-
-
-
-
+if __name__ == "__main__":
+    main()

--- a/src/1.02-fit-double-logistic-to_scaled_ndvi.py
+++ b/src/1.02-fit-double-logistic-to_scaled_ndvi.py
@@ -1,375 +1,310 @@
-#!/usr/bin/env python
-# coding: utf-8
+#!/usr/bin/env python3
+"""Fit sigmoid double sawtooth models to scaled NDVI observations."""
 
-# In[1]:
+from __future__ import annotations
 
+from pathlib import Path
+from typing import Iterable, Tuple
 
-import os
 import h5py
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 from scipy.ndimage import median_filter
 from scipy.optimize import curve_fit
 
 
-# In[2]:
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DATA_PATH = PROJECT_ROOT / "data" / "intermediate" / "ndvi_stack_optimized.h5"
+FIGURE_ROOT = PROJECT_ROOT / "figure"
+SCRIPT_STEM = Path(__file__).stem
+SCRIPT_FIGURE_DIR = FIGURE_ROOT / SCRIPT_STEM
+SCRIPT_FIGURE_DIR.mkdir(parents=True, exist_ok=True)
 
 
-# Path to HDF5 file
-hdf5_file = "/net/sno/pschluet/green_wave/data/intermediate/ndvi_stack_optimized.h5"
+def _slugify(text: str) -> str:
+    return (
+        text.replace("+", "p")
+        .replace("-", "m")
+        .replace(" ", "_")
+        .replace("/", "-")
+        .replace(".", "p")
+    )
 
 
-# In[3]:
+def _save_figure(fig: plt.Figure, description: str) -> Path:
+    filename = f"{SCRIPT_STEM}__{_slugify(description)}.png"
+    path = SCRIPT_FIGURE_DIR / filename
+    fig.savefig(path, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved figure to {path}")
+    return path
 
 
-# -------------------------------
-# Function to extract NDVI time series for a given lat/lon
-# -------------------------------
-def get_ndvi_timeseries(lat, lon):
-    """Extract NDVI time series from HDF5 for a given latitude & longitude."""
-    
-    # Convert latitude & longitude to row/column indices
-    row_idx = int((90 - lat) / 0.05)  # Convert latitude to row
-    col_idx = int((lon + 180) / 0.05)  # Convert longitude to column
+def _coordinate_tag(lat: float, lon: float) -> str:
+    return _slugify(f"lat{lat:.1f}_lon{lon:.1f}")
+
+
+def get_ndvi_timeseries(
+    lat: float, lon: float
+) -> Tuple[list[pd.Timestamp], np.ndarray]:
+    """Extract NDVI time series from the HDF5 stack for a location."""
+
+    if not DATA_PATH.exists():
+        raise FileNotFoundError(f"NDVI stack not found at {DATA_PATH}")
+
+    row_idx = int((90 - lat) / 0.05)
+    col_idx = int((lon + 180) / 0.05)
     print(f"Nearest pixel index: row={row_idx}, col={col_idx}")
 
-    # Open HDF5 file and read metadata and NDVI time series
-    with h5py.File(hdf5_file, "r") as h5f:
-        metadata = h5f["metadata"][:]  # Load (year, doy)
-        ndvi_timeseries = h5f["ndvi_stack"][:, row_idx, col_idx]  # Load only the required pixel
+    with h5py.File(DATA_PATH, "r") as h5f:
+        metadata = h5f["metadata"][:]
+        ndvi_timeseries = h5f["ndvi_stack"][:, row_idx, col_idx]
 
-    # Convert metadata (year, DOY) to actual dates
-    dates = [pd.to_datetime(f"{year}-{doy:03d}", format="%Y-%j") for year, doy in metadata]
-
+    dates = [
+        pd.to_datetime(f"{year}-{doy:03d}", format="%Y-%j") for year, doy in metadata
+    ]
     return dates, ndvi_timeseries
 
 
-# In[4]:
+def process_ndvi(dates: Iterable[pd.Timestamp], ndvi_timeseries: np.ndarray) -> tuple:
+    """Clip winter values and scale the NDVI series to [0, 1]."""
 
-
-# -------------------------------
-# Function to process NDVI time series
-# -------------------------------
-def process_ndvi(dates, ndvi_timeseries):
-    """Apply winter correction and moving median filter to NDVI time series."""
-
-    # Compute 2.5% quantile (winter baseline)
     winter_ndvi = np.nanquantile(ndvi_timeseries, 0.025)
-
-    # Apply winter NDVI correction (clip values below threshold)
     corrected_ndvi = np.copy(ndvi_timeseries)
     corrected_ndvi[ndvi_timeseries < winter_ndvi] = winter_ndvi
-    
-    
 
-   # # Replace missing values in winter period (DOY 300-365 & 1-60)
-   # for i, date in enumerate(dates):
-   #     doy = date.day_of_year
-   #     if np.isnan(corrected_ndvi[i]) and (doy >= 300 or doy <= 60):
-   #         corrected_ndvi[i] = winter_ndvi
-
-    # Apply Moving Median Filter (window size = 3)
     filtered_ndvi = median_filter(corrected_ndvi, size=3)
-    filtered_ndvi = (filtered_ndvi -np.nanquantile(filtered_ndvi, 0.025)) 
-    filtered_ndvi  = filtered_ndvi/ np.nanquantile(filtered_ndvi, 0.995)
+    lower = np.nanquantile(filtered_ndvi, 0.025)
+    upper = np.nanquantile(filtered_ndvi, 0.995)
+    scale = upper - lower
+    if np.isclose(scale, 0):
+        scaled_ndvi = np.zeros_like(filtered_ndvi)
+    else:
+        scaled_ndvi = (filtered_ndvi - lower) / scale
 
-    return winter_ndvi, corrected_ndvi, filtered_ndvi
+    return winter_ndvi, corrected_ndvi, scaled_ndvi
 
 
-# In[5]:
-
-
-# -------------------------------
-# Function to plot NDVI time series
-# -------------------------------
-def plot_ndvi(lat, lon):
-    """Extract, process, and plot NDVI time series for a given location."""
-    
+def plot_ndvi(lat: float, lon: float) -> None:
     dates, ndvi_timeseries = get_ndvi_timeseries(lat, lon)
-    winter_ndvi, corrected_ndvi, filtered_ndvi = process_ndvi(dates, ndvi_timeseries)
+    winter_ndvi, corrected_ndvi, scaled_ndvi = process_ndvi(dates, ndvi_timeseries)
 
-    plt.figure(figsize=(12, 6))
-
-
-
-    # Corrected NDVI (baseline applied)
-    plt.plot(dates, corrected_ndvi, marker="o", linestyle="-", color="green", label="Corrected NDVI")
-
-    # Filtered NDVI
-    plt.plot(dates, filtered_ndvi, marker="o", linestyle="-", color="red", label="Filtered NDVI (Moving Median)")
-
-    plt.xlabel("Date")
-    plt.ylabel("NDVI")
-    plt.title(f"NDVI Time Series at ({lat}°N, {lon}°E)")
-    plt.legend()
-    plt.grid(True)
-    plt.show()
-
-
-# In[6]:
-
-
-plot_ndvi(60, 16)
-
-
-# In[7]:
-
-
-plot_ndvi(50, 16)
-
-
-# In[8]:
+    fig, ax = plt.subplots(figsize=(12, 6))
+    ax.plot(
+        dates,
+        corrected_ndvi,
+        marker="o",
+        linestyle="-",
+        color="green",
+        label="Corrected NDVI",
+    )
+    ax.plot(
+        dates,
+        scaled_ndvi,
+        marker="o",
+        linestyle="-",
+        color="red",
+        label="Scaled & Filtered NDVI",
+    )
+    ax.axhline(
+        y=winter_ndvi,
+        color="blue",
+        linestyle="--",
+        label=f"Winter NDVI ({winter_ndvi:.3f})",
+    )
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Scaled NDVI")
+    ax.set_title(f"Scaled NDVI Time Series at ({lat}°N, {lon}°E)")
+    ax.legend()
+    ax.grid(True)
+    _save_figure(fig, f"{_coordinate_tag(lat, lon)}_scaled_timeseries")
 
 
 def sigmoid_double_sawtooth(
-    t, z1, d1, z2, d2, period=365,return_derivative=False
+    t: np.ndarray,
+    z1: float,
+    d1: float,
+    z2: float,
+    d2: float,
+    bias: float,
+    scale: float,
+    period: float = 365,
+    return_derivative: bool = False,
 ):
-    """
-    Compute s(t) = sigmoid(double_sawtooth(t)) in one pass.
-    Optionally also return ds/dt = d/dt [sigmoid(double_sawtooth(t))].
-
-    Parameters
-    ----------
-    t : array-like
-        Time points at which to evaluate.
-    period : float
-        The period (e.g. 365).
-    z1, d1 : float
-        Offset & slope for the increasing sawtooth (st1).
-    z2, d2 : float
-        Offset & slope for the decreasing sawtooth (st2).
-    return_derivative : bool, optional
-        If True, also return ds/dt in addition to s(t).
-
-    Returns
-    -------
-    s_values : ndarray
-        The values of sigmoid(double_sawtooth(t)).
-    ds_dt_values : ndarray (only if return_derivative=True)
-        The derivative d/dt [sigmoid(double_sawtooth(t))].
-    """
-    z1 = z1 % 365
-    z2 = z2 % 365
-    d1 = 1/d1
-    d2 = 1/d2
+    z1 = z1 % period
+    z2 = z2 % period
+    d1 = 1 / d1
+    d2 = 1 / d2
     t = np.asarray(t)
 
-    # 1) Find the two crossing times in [0, period)
     c1, c2 = _get_crossings(z1, d1, z2, d2, period)
-
-    # 2) Evaluate st1, st2 at the crossing times c1, c2 to see which is "lowest" or "highest"
     val1 = _sawtooth_zp_d(c1, period, z1, d1)
     val2 = _sawtooth_zp_d(c2, period, z1, d1)
 
-    # We'll define the piecewise intervals:
     modt = t % period
-    in_first  = (modt < c1)
+    in_first = modt < c1
     in_second = (modt >= c1) & (modt < c2)
-    # The complement is the third interval: modt >= c2
 
-    # Pre-allocate outputs
-    x_vals = np.zeros_like(t)  # double_sawtooth(t)
+    x_vals = np.zeros_like(t)
     if return_derivative:
-        xprime_vals = np.zeros_like(t)  # piecewise slope d1 or d2
+        xprime_vals = np.zeros_like(t)
 
-    # 3) Fill in piecewise segments
-    # If val1 < val2 => c1 is 'lowest crossing', c2 is 'highest crossing',
-    # => st1 used on [c1,c2), st2 on [0,c1) & [c2,P).
-    # Otherwise st2 used on [c1,c2), st1 on outside.
     if val1 < val2:
-        # st2 in [0,c1) and [c2,P), st1 in [c1,c2)
-        x_vals[in_first]  = _sawtooth_zp_d(t[in_first],  period, z2, d2)
+        x_vals[in_first] = _sawtooth_zp_d(t[in_first], period, z2, d2)
         x_vals[in_second] = _sawtooth_zp_d(t[in_second], period, z1, d1)
-        x_vals[~(in_first | in_second)] = _sawtooth_zp_d(t[~(in_first | in_second)], period, z2, d2)
-
+        x_vals[~(in_first | in_second)] = _sawtooth_zp_d(
+            t[~(in_first | in_second)], period, z2, d2
+        )
         if return_derivative:
-            xprime_vals[in_first]  = d2
+            xprime_vals[in_first] = d2
             xprime_vals[in_second] = d1
             xprime_vals[~(in_first | in_second)] = d2
     else:
-        # st1 in [0,c1) and [c2,P), st2 in [c1,c2)
-        x_vals[in_first]  = _sawtooth_zp_d(t[in_first],  period, z1, d1)
+        x_vals[in_first] = _sawtooth_zp_d(t[in_first], period, z1, d1)
         x_vals[in_second] = _sawtooth_zp_d(t[in_second], period, z2, d2)
-        x_vals[~(in_first | in_second)] = _sawtooth_zp_d(t[~(in_first | in_second)], period, z1, d1)
-
+        x_vals[~(in_first | in_second)] = _sawtooth_zp_d(
+            t[~(in_first | in_second)], period, z1, d1
+        )
         if return_derivative:
-            xprime_vals[in_first]  = d1
+            xprime_vals[in_first] = d1
             xprime_vals[in_second] = d2
             xprime_vals[~(in_first | in_second)] = d1
 
-    # 4) Sigmoid
     s_vals = _logistic(x_vals)
 
     if return_derivative:
-        # dsigma/dx = s * (1 - s)
         dsigma_dx = s_vals * (1 - s_vals)
-        # By chain rule: d/dt [sigma(x(t))] = dsigma/dx * dx/dt
         ds_dt = dsigma_dx * xprime_vals
-        return s_vals, ds_dt
+        return s_vals * scale + bias, ds_dt * scale
 
-    else:
-        # Just return the sigmoid
-        return s_vals
+    return s_vals * scale + bias
 
 
-# --- Small helpers (underscored to show they are "private") ---
-def _sawtooth_zp_d(tt, period, z, d):
-    """Compute the standard sawtooth at times tt, with offset z, slope d."""
-    return (((tt - z - period/2) % period) - period/2) * d
+def _sawtooth_zp_d(tt: np.ndarray, period: float, z: float, d: float) -> np.ndarray:
+    return (((tt - z - period / 2) % period) - period / 2) * d
 
-def _logistic(x):
-    """Sigmoid."""
+
+def _logistic(x: np.ndarray) -> np.ndarray:
     return 1 / (1 + np.exp(-x))
 
-def _get_crossings(z1, d1, z2, d2, period=365):
-    """
-    Return the two crossing times c1, c2 in ascending order.
-    If fewer than 2, just pick c1=0, c2=period/2 to avoid errors.
-    """
+
+def _get_crossings(
+    z1: float, d1: float, z2: float, d2: float, period: float = 365
+) -> tuple:
     crossings = _find_sawtooth_intersections(z1, d1, z2, d2, period)
     if len(crossings) < 2:
-        return (0.0, period / 2)
+        return 0.0, period / 2
     return crossings[0], crossings[1]
 
-def _find_sawtooth_intersections(z1, d1, z2, d2, period=365):
-    """Analytic intersection solver, same logic as before."""
+
+def _find_sawtooth_intersections(
+    z1: float, d1: float, z2: float, d2: float, period: float = 365
+) -> list:
     z1_mod = z1 % period
     z2_mod = z2 % period
 
     r = d2 / d1
     dprime = (z1_mod - z2_mod) % period
 
-    # T1
-    num1 = r*dprime + (period/2)*(1 - r)
-    den = (1 - r)
+    num1 = r * dprime + (period / 2) * (1 - r)
+    den = 1 - r
     T1 = num1 / den
 
-    # T2
-    num2 = r*dprime + (period/2)*(1 - 3*r)
+    num2 = r * dprime + (period / 2) * (1 - 3 * r)
     T2 = num2 / den
 
-    solutions = []
+    solutions: list[float] = []
     if 0 <= T1 < (period - dprime):
-        c1 = (z1_mod + (period/2) + T1) % period
+        c1 = (z1_mod + (period / 2) + T1) % period
         solutions.append(c1)
     if (period - dprime) <= T2 < period:
-        c2 = (z1_mod + (period/2) + T2) % period
+        c2 = (z1_mod + (period / 2) + T2) % period
         solutions.append(c2)
 
     solutions.sort()
     return solutions
 
 
-# In[9]:
-
-
-# -------------------------------
-# Function to fit sigmoid_double_sawtooth to NDVI data
-# -------------------------------
-def fit_sigmoid_double_sawtooth(lat, lon):
-    """Fit sigmoid_double_sawtooth function to NDVI time series at given location."""
-    
-    # Extract and process NDVI data
+def fit_sigmoid_double_sawtooth(lat: float, lon: float) -> np.ndarray | None:
     dates, ndvi_timeseries = get_ndvi_timeseries(lat, lon)
-    _, _, filtered_ndvi = process_ndvi(dates, ndvi_timeseries)
+    _, _, scaled_ndvi = process_ndvi(dates, ndvi_timeseries)
 
-    # Convert dates to numeric values (days of year)
     doy = np.array([date.day_of_year for date in dates])
-
-    # Initial parameter guesses: (z1, d1, z2, d2, bias, scale)
-    
-    
-
-
-    # Interpolate NaN values
-    valid_mask = ~np.isnan(filtered_ndvi) & ~np.isinf(filtered_ndvi)
+    valid_mask = ~np.isnan(scaled_ndvi) & ~np.isinf(scaled_ndvi)
     doy_valid = doy[valid_mask]
-    ndvi_valid = filtered_ndvi[valid_mask]
-    
-    initial_guess = [100, 50, 250, -50]
+    ndvi_valid = scaled_ndvi[valid_mask]
 
-    # Fit the model
-    try:
-        params, _ = curve_fit(
-            sigmoid_double_sawtooth, doy_valid, ndvi_valid,
-            p0=initial_guess, bounds=([-np.inf, 0, -np.inf, -np.inf ], [np.inf, np.inf, np.inf, 0])
-        )
-        print("Optimized Parameters:", params)
-    except RuntimeError as e:
-        print("Fit failed:", e)
+    if doy_valid.size == 0:
+        print("No valid NDVI observations available for fitting.")
         return None
 
-    # Plot results
-    plt.figure(figsize=(12, 6))
-    plt.scatter(doy, filtered_ndvi, label="Filtered NDVI", color="black", alpha=0.3)
+    initial_guess = [
+        100,
+        50,
+        250,
+        -50,
+        float(np.mean(ndvi_valid)),
+        float(np.ptp(ndvi_valid)),
+    ]
+
+    try:
+        params, _ = curve_fit(
+            sigmoid_double_sawtooth,
+            doy_valid,
+            ndvi_valid,
+            p0=initial_guess,
+            bounds=(
+                [-np.inf, 0, -np.inf, -np.inf, -np.inf, 1e-5],
+                [np.inf, np.inf, np.inf, 0, np.inf, np.inf],
+            ),
+        )
+    except RuntimeError as exc:
+        print(f"Fit failed: {exc}")
+        return None
+
+    print(
+        "Optimized Parameters:",
+        {
+            "z1": params[0],
+            "d1": params[1],
+            "z2": params[2],
+            "d2": params[3],
+            "bias": params[4],
+            "scale": params[5],
+        },
+    )
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+    ax.scatter(doy, scaled_ndvi, label="Scaled NDVI", color="red", alpha=0.6)
     t_fit = np.linspace(1, 365, 1000)
-    plt.plot(t_fit, sigmoid_double_sawtooth(t_fit, *params), label="Fitted Curve", color="red", linestyle="--", linewidth=2,)
-    plt.axvline(params[0] %365, color="green", linestyle=":",linewidth=2, label="Spring Inflection")
-    plt.axvline(params[2] %365, color="orange", linestyle=":",linewidth=2, label="Autumn Inflection")
-    plt.xlabel("Day of Year")
-    plt.ylabel("NDVI")
-    plt.title(f"NDVI Fit at ({lat}°N, {lon}°E)")
-    plt.legend()
-    plt.grid(True)
-    plt.show()
+    ax.plot(
+        t_fit,
+        sigmoid_double_sawtooth(t_fit, *params),
+        label="Fitted Curve",
+        color="blue",
+    )
+    ax.set_xlabel("Day of Year")
+    ax.set_ylabel("Scaled NDVI")
+    ax.set_title(f"Scaled NDVI Fit at ({lat}°N, {lon}°E)")
+    ax.legend()
+    ax.grid(True)
+    _save_figure(fig, f"{_coordinate_tag(lat, lon)}_scaled_fit")
 
     return params
 
-# Example usage
-fit_params = fit_sigmoid_double_sawtooth(60, 16)
+
+def main() -> None:
+    coordinates = [
+        (60, 16),
+        (50, 16),
+    ]
+
+    for lat, lon in coordinates:
+        print(f"\nProcessing location ({lat}°N, {lon}°E)")
+        plot_ndvi(lat, lon)
+        fit_sigmoid_double_sawtooth(lat, lon)
 
 
-# In[10]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(61, 16)
-
-
-# In[11]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(59, 16)
-
-
-# In[12]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(60, 15)
-
-
-# In[13]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(50, 16)
-
-
-# In[14]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(40, 16)
-
-
-# In[15]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(30, 16)
-
-
-# In[16]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(20, 16)
-
-
-# In[17]:
-
-
-fit_params = fit_sigmoid_double_sawtooth(-33, 27)
-
-
-# In[ ]:
-
-
-
-
+if __name__ == "__main__":
+    main()

--- a/src/1.03-fit-gaussia_to_ndvi.py
+++ b/src/1.03-fit-gaussia_to_ndvi.py
@@ -1,163 +1,155 @@
-#!/usr/bin/env python
-# coding: utf-8
+#!/usr/bin/env python3
+"""Fit cyclic Gaussian models to NDVI time series for selected locations."""
 
-# In[10]:
+from __future__ import annotations
 
+from pathlib import Path
 
-#!/usr/bin/env python
-# coding: utf-8
-
-import os
 import h5py
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 from scipy.ndimage import median_filter
 from scipy.optimize import curve_fit
 
-# Path to HDF5 file
-directory = "/net/sno/pschluet/green_wave/data/intermediate"
-hdf5_file = os.path.join(directory, "ndvi_stack_optimized.h5")
 
-# -------------------------------
-# Function to extract NDVI time series for a given lat/lon
-# -------------------------------
-def get_ndvi_timeseries(lat, lon):
-    """Extract NDVI time series from HDF5 for a given latitude & longitude."""
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DATA_PATH = PROJECT_ROOT / "data" / "intermediate" / "ndvi_stack_optimized.h5"
+FIGURE_ROOT = PROJECT_ROOT / "figure"
+SCRIPT_STEM = Path(__file__).stem
+SCRIPT_FIGURE_DIR = FIGURE_ROOT / SCRIPT_STEM
+SCRIPT_FIGURE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _slugify(text: str) -> str:
+    return (
+        text.replace("+", "p")
+        .replace("-", "m")
+        .replace(" ", "_")
+        .replace("/", "-")
+        .replace(".", "p")
+    )
+
+
+def _save_figure(fig: plt.Figure, description: str) -> Path:
+    filename = f"{SCRIPT_STEM}__{_slugify(description)}.png"
+    path = SCRIPT_FIGURE_DIR / filename
+    fig.savefig(path, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved figure to {path}")
+    return path
+
+
+def _coordinate_tag(lat: float, lon: float) -> str:
+    return _slugify(f"lat{lat:.1f}_lon{lon:.1f}")
+
+
+def get_ndvi_timeseries(lat: float, lon: float) -> tuple[np.ndarray, np.ndarray]:
+    if not DATA_PATH.exists():
+        raise FileNotFoundError(f"NDVI stack not found at {DATA_PATH}")
+
     row_idx = int((90 - lat) / 0.05)
     col_idx = int((lon + 180) / 0.05)
     print(f"Nearest pixel index: row={row_idx}, col={col_idx}")
 
-    with h5py.File(hdf5_file, "r") as h5f:
-        metadata = h5f["metadata"][:]  # (year, doy)
+    with h5py.File(DATA_PATH, "r") as h5f:
+        metadata = h5f["metadata"][:]
         ndvi_stack = h5f["ndvi_stack"][:, row_idx, col_idx]
 
-    dates = [pd.to_datetime(f"{year}-{doy:03d}", format="%Y-%j") for year, doy in metadata]
-    return np.array([d.day_of_year for d in dates]), ndvi_stack
+    dates = [
+        pd.to_datetime(f"{year}-{doy:03d}", format="%Y-%j") for year, doy in metadata
+    ]
+    return np.array([date.day_of_year for date in dates]), ndvi_stack
 
-# -------------------------------
-# Function to process NDVI time series
-# -------------------------------
-def process_ndvi(doy, ndvi_timeseries):
-    """Apply winter correction and moving median filter to NDVI time series."""
+
+def process_ndvi(doy: np.ndarray, ndvi_timeseries: np.ndarray) -> tuple:
     winter_ndvi = np.nanquantile(ndvi_timeseries, 0.025)
     corrected = np.copy(ndvi_timeseries)
     corrected[np.isnan(corrected)] = winter_ndvi
     corrected[corrected < winter_ndvi] = winter_ndvi
-
     filtered = median_filter(corrected, size=3)
-    #filtered = (filtered - np.nanquantile(filtered, 0.025))
-    #filtered = filtered / np.nanquantile(filtered, 0.995)
     return winter_ndvi, corrected, filtered
 
-# -------------------------------
-# Periodic Gaussian (wrapped) definition
-# -------------------------------
-def gaussian_cyclic(t, A, mu, sigma, C, period=365):
-    """
-    Periodic (wrapped) Gaussian function on [0, period).
-    t : array-like days of year
-    A : amplitude
-    mu : peak location (day of year)
-    sigma : standard deviation
-    C : baseline offset
-    """
-    # compute minimal distance on circle
-    delta = ((t - mu + period/2) % period) - period/2
-    return C + A * np.exp(-0.5 * (delta / sigma)**2)
 
-# -------------------------------
-# Function to calculate Gaussian fit and R-squared
-# -------------------------------
-def calculate_gaussian_fit(lat, lon):
-    """Calculate cyclic Gaussian fit parameters for NDVI at a given location.
+def gaussian_cyclic(
+    t: np.ndarray, A: float, mu: float, sigma: float, C: float, period: float = 365
+) -> np.ndarray:
+    delta = ((t - mu + period / 2) % period) - period / 2
+    return C + A * np.exp(-0.5 * (delta / sigma) ** 2)
 
-    Returns:
-        popt : array, fitted parameters [A, mu, sigma, C]
-        r_squared : float, coefficient of determination
-    """
-    # load and process
+
+def calculate_gaussian_fit(
+    lat: float, lon: float
+) -> tuple[np.ndarray | None, float | None]:
     doy, ndvi = get_ndvi_timeseries(lat, lon)
     _, _, filtered_ndvi = process_ndvi(doy, ndvi)
 
-    # mask invalid
     mask = ~np.isnan(filtered_ndvi) & ~np.isinf(filtered_ndvi)
     x = doy[mask]
     y = filtered_ndvi[mask]
 
-    # initial guesses
-    A0 = np.nanmax(y) - np.nanmin(y)
-    mu0 = x[np.argmax(y)]
-    sigma0 = 30
-    C0 = np.nanmin(y)
+    if x.size == 0:
+        print("No valid NDVI observations available for fitting.")
+        return None, None
+
+    A0 = float(np.nanmax(y) - np.nanmin(y))
+    mu0 = float(x[np.argmax(y)]) if x.size else 180.0
+    sigma0 = 30.0
+    C0 = float(np.nanmin(y))
     p0 = [A0, mu0, sigma0, C0]
     bounds = ([0, -365, 0, -np.inf], [np.inf, 365, 365, np.inf])
 
-    # fit
     try:
-        popt, pcov = curve_fit(gaussian_cyclic, x, y, p0=p0, bounds=bounds)
-    except RuntimeError as e:
-        print("Gaussian fit failed:", e)
+        popt, _ = curve_fit(gaussian_cyclic, x, y, p0=p0, bounds=bounds)
+    except RuntimeError as exc:
+        print(f"Gaussian fit failed: {exc}")
         return None, None
 
-    [A_opt, mu_opt, sigma_opt, C_opt] = popt
-    popt = [A_opt, mu_opt % 365, sigma_opt, C_opt]
-    # compute R-squared
+    popt = np.array([popt[0], popt[1] % 365, popt[2], popt[3]], dtype=float)
     y_fit = gaussian_cyclic(x, *popt)
-    ss_res = np.sum((y - y_fit)**2)
-    ss_tot = np.sum((y - np.mean(y))**2)
-    r_squared = 1 - ss_res/ss_tot
+    ss_res = np.sum((y - y_fit) ** 2)
+    ss_tot = np.sum((y - np.mean(y)) ** 2)
+    r_squared = 1 - ss_res / ss_tot if ss_tot != 0 else float("nan")
 
-    return popt, r_squared
+    print(
+        "Optimized Parameters:",
+        {"A": popt[0], "mu": popt[1], "sigma": popt[2], "C": popt[3], "R2": r_squared},
+    )
 
-# -------------------------------
-# Function to plot data and Gaussian fit
-# -------------------------------
-def plot_gaussian_fit(lat, lon, popt, r_squared=None):
-    """Plot filtered NDVI and fitted cyclic Gaussian at a given location."""
-    # reload data
+    return popt, float(r_squared)
+
+
+def plot_gaussian_fit(
+    lat: float, lon: float, popt: np.ndarray, r_squared: float | None
+) -> None:
     doy, ndvi = get_ndvi_timeseries(lat, lon)
     _, _, filtered_ndvi = process_ndvi(doy, ndvi)
 
-    # unpack params
-    A_fit, mu_fit, sigma_fit, C_fit = popt
-
-    # scatter
-    plt.figure(figsize=(12,6))
-    plt.scatter(doy, filtered_ndvi, color='grey', alpha=0.4, label='Filtered NDVI')
-
-    # fit curve
+    fig, ax = plt.subplots(figsize=(12, 6))
+    ax.scatter(doy, filtered_ndvi, color="grey", alpha=0.4, label="Filtered NDVI")
     t_fit = np.linspace(1, 365, 1000)
-    y_fit = gaussian_cyclic(t_fit, *popt)
-    plt.plot(t_fit, y_fit, 'r--', lw=2, label='Gaussian Fit')
-    plt.axvline(mu_fit, color='blue', ls=':', lw=2, label='Peak Day')
-
-    # labels and title
-    plt.xlabel('Day of Year')
-    plt.ylabel('Normalized NDVI')
-    title = f'Gaussian Fit (cyclic) at ({lat}°N, {lon}°E)'
-    if r_squared is not None:
-        title += f' — $R^2$={r_squared:.3f}'
-    plt.title(title)
-    plt.legend()
-    plt.grid(True)
-    plt.show()
+    ax.plot(t_fit, gaussian_cyclic(t_fit, *popt), "r--", lw=2, label="Gaussian Fit")
+    ax.axvline(popt[1], color="blue", ls=":", lw=2, label="Peak Day")
+    ax.set_xlabel("Day of Year")
+    ax.set_ylabel("NDVI")
+    title = f"Gaussian Fit at ({lat}°N, {lon}°E)"
+    if r_squared is not None and not np.isnan(r_squared):
+        title += f" — $R^2$={r_squared:.3f}"
+    ax.set_title(title)
+    ax.legend()
+    ax.grid(True)
+    _save_figure(fig, f"{_coordinate_tag(lat, lon)}_gaussian_fit")
 
 
-coords = [(60, 16), (50, 16), (30, 16)]
-for lat, lon in coords:
-    print(f"\nCalculating fit at ({lat}, {lon})")
-    popt, r2 = calculate_gaussian_fit(lat, lon)
-    if popt is not None:
-        print(f"Fitted params: A={popt[0]:.3f}, mu={popt[1]:.1f}, sigma={popt[2]:.1f}, C={popt[3]:.3f}")
-        print(f"R-squared: {r2:.3f}")
-        plot_gaussian_fit(lat, lon, popt, r2)
-    else:
-        print("Fit failed for this location.")
+def main() -> None:
+    coordinates = [(60, 16), (50, 16), (30, 16)]
+
+    for lat, lon in coordinates:
+        print(f"\nCalculating fit at ({lat}°N, {lon}°E)")
+        popt, r2 = calculate_gaussian_fit(lat, lon)
+        if popt is not None:
+            plot_gaussian_fit(lat, lon, popt, r2)
 
 
-# In[ ]:
-
-
-
-
+if __name__ == "__main__":
+    main()

--- a/src/2.01_plot_insolation.py
+++ b/src/2.01_plot_insolation.py
@@ -1,20 +1,44 @@
-#!/usr/bin/env python
-# coding: utf-8
+#!/usr/bin/env python3
+"""Generate diagnostic plots for insolation and orbital parameters."""
 
-# In[1]:
+from __future__ import annotations
 
+from pathlib import Path
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d
-import matplotlib.pyplot as plt
 
 
-# In[4]:
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+INSOLATION_PATH = PROJECT_ROOT / "data" / "insolation" / "orbit91"
+FIGURE_ROOT = PROJECT_ROOT / "figure"
+SCRIPT_STEM = Path(__file__).stem
+SCRIPT_FIGURE_DIR = FIGURE_ROOT / SCRIPT_STEM
+SCRIPT_FIGURE_DIR.mkdir(parents=True, exist_ok=True)
 
 
-# === unwrap function (phase‐unwrap for perihelion longitude) ===
-def unwrap(p):
+def _slugify(text: str) -> str:
+    return (
+        text.replace("+", "p")
+        .replace("-", "m")
+        .replace(" ", "_")
+        .replace("/", "-")
+        .replace(".", "p")
+    )
+
+
+def _save_figure(fig: plt.Figure, description: str) -> Path:
+    filename = f"{SCRIPT_STEM}__{_slugify(description)}.png"
+    path = SCRIPT_FIGURE_DIR / filename
+    fig.savefig(path, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved figure to {path}")
+    return path
+
+
+def unwrap(p: np.ndarray) -> np.ndarray:
     p = np.asarray(p)
     up = np.zeros_like(p)
     pm1 = p[0]
@@ -36,228 +60,265 @@ def unwrap(p):
         up[i] = cp
     return up
 
-# === Load and interpolate orbital parameters ===
-_ins_data = pd.read_csv(
-    '/work/pschluet/green_wave/data/insolation/orbit91',
-    sep=r'\s+',            # regex for any amount of whitespace
-    skiprows=2,            # skip the “INSOLATION” header and the column‐names line
-    usecols=[0, 1, 2, 3],  # only the first four fields: kyear, ecc, omega, obliquity
-    header=None,
-    names=['kyear', 'ecc', 'omega', 'epsilon']
-)
 
-_kyear0 = -_ins_data['kyear'].values
-_ecc0    =  _ins_data['ecc'].values
-_omega0  =  _ins_data['omega'].values + 180.0         # R adds 180°
-_omega0u =  unwrap(np.deg2rad(_omega0))              # convert to radians & unwrap
-_eps0    =  _ins_data['epsilon'].values              # in degrees
-
-# cubic spline interpolators (extrapolate beyond ends if needed)
-_f_ecc     = interp1d(_kyear0, _ecc0,    kind='cubic', fill_value='extrapolate')
-_f_omega   = interp1d(_kyear0, _omega0u, kind='cubic', fill_value='extrapolate')
-_f_epsilon = interp1d(_kyear0, _eps0,    kind='cubic', fill_value='extrapolate')
+_INTERPOLATORS: dict[str, interp1d] | None = None
+_KYEARS_FULL: np.ndarray | None = None
+_ECC_FULL: np.ndarray | None = None
+_EPS_FULL: np.ndarray | None = None
+_OMG_FULL: np.ndarray | None = None
 
 
-# In[5]:
+def _ensure_orbital_data_loaded() -> None:
+    global _INTERPOLATORS, _KYEARS_FULL, _ECC_FULL, _EPS_FULL, _OMG_FULL
+
+    if _INTERPOLATORS is not None:
+        return
+
+    if not INSOLATION_PATH.exists():
+        raise FileNotFoundError(
+            f"Orbital parameter file not found at {INSOLATION_PATH}"
+        )
+
+    print(f"Loading orbital parameters from {INSOLATION_PATH} …")
+    ins_data = pd.read_csv(
+        INSOLATION_PATH,
+        sep=r"\s+",
+        skiprows=2,
+        usecols=[0, 1, 2, 3],
+        header=None,
+        names=["kyear", "ecc", "omega", "epsilon"],
+    )
+
+    kyear0 = -ins_data["kyear"].values
+    ecc0 = ins_data["ecc"].values
+    omega0 = ins_data["omega"].values + 180.0
+    omega0u = unwrap(np.deg2rad(omega0))
+    eps0 = ins_data["epsilon"].values
+
+    f_ecc = interp1d(kyear0, ecc0, kind="cubic", fill_value="extrapolate")
+    f_omega = interp1d(kyear0, omega0u, kind="cubic", fill_value="extrapolate")
+    f_epsilon = interp1d(kyear0, eps0, kind="cubic", fill_value="extrapolate")
+
+    _INTERPOLATORS = {"ecc": f_ecc, "omega": f_omega, "epsilon": f_epsilon}
+
+    _KYEARS_FULL = np.arange(0, 50000 + 1) / 10.0
+    _ECC_FULL = f_ecc(_KYEARS_FULL)
+    _EPS_FULL = np.deg2rad(f_epsilon(_KYEARS_FULL))
+    _OMG_FULL = f_omega(_KYEARS_FULL)
+
+    print(f"Loaded {len(ins_data)} orbital parameter records.")
 
 
-def orbital_parameters(kyear):
-    """
-    Return (ecc, epsilon_rad, omega_rad) for any kyear (kyr BP).
-    """
-    ecc     = _f_ecc(kyear)
-    epsilon = np.deg2rad(_f_epsilon(kyear))
-    omega   = _f_omega(kyear)   # already in radians
+def orbital_parameters(
+    kyear: float | np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    _ensure_orbital_data_loaded()
+    assert _INTERPOLATORS is not None
+
+    ecc = _INTERPOLATORS["ecc"](kyear)
+    epsilon = np.deg2rad(_INTERPOLATORS["epsilon"](kyear))
+    omega = _INTERPOLATORS["omega"](kyear)
     return ecc, epsilon, omega
 
-# Pre‐compute global arrays for fast lookup (every 0.1 kyr from 0 to 5 Myr)
-_kyears_full = np.arange(0, 50000 + 1) / 10.0
-_ecc_full, _eps_full, _omg_full = orbital_parameters(_kyears_full)
 
-def orbital_parameters_fast(kyear):
-    """
-    Fast lookup of (ecc, epsilon_rad, omega_rad) assuming kyear*10 is integer.
-    """
+def orbital_parameters_fast(kyear: float) -> tuple[float, float, float]:
+    _ensure_orbital_data_loaded()
+    assert _KYEARS_FULL is not None and _ECC_FULL is not None
+    assert _EPS_FULL is not None and _OMG_FULL is not None
+
     idx = int(np.round(kyear * 10))
-    return _ecc_full[idx], _eps_full[idx], _omg_full[idx]
+    return float(_ECC_FULL[idx]), float(_EPS_FULL[idx]), float(_OMG_FULL[idx])
 
-def tlag(data, ilag):
-    """
-    Replicate R's tlag: tile data 3×, then take slice [365:730-ilag] (0‐based).
-    """
+
+def tlag(data: np.ndarray, ilag: int) -> np.ndarray:
     data = np.asarray(data)
     temp = np.tile(data, 3)
     start = len(data)
-    end   = start + len(data) - ilag
+    end = start + len(data) - ilag
     return temp[start:end]
 
-def daily_insolation_param(lat, day, ecc, obliquity, long_perh, day_type=1):
-    """
-    Translated from R's daily_insolation_param.
-    lat in degrees, day scalar or array,
-    ecc scalar or array, obliquity & long_perh in degrees.
-    Returns dict with keys 'Fsw','ecc','obliquity','long_perh','lambda'.
-    """
+
+def daily_insolation_param(
+    lat: float,
+    day: np.ndarray,
+    ecc: np.ndarray,
+    obliquity: np.ndarray,
+    long_perh: np.ndarray,
+    day_type: int = 1,
+) -> dict[str, np.ndarray]:
     ε = np.deg2rad(obliquity)
     ω = np.deg2rad(long_perh)
     φ = np.deg2rad(lat)
     day = np.asarray(day, dtype=float)
 
-    # solar longitude λ
     if day_type == 1:
-        Δλ_m = (day - 80.0) * 2*np.pi / 365.2422
-        β    = np.sqrt(1 - ecc**2)
+        Δλ_m = (day - 80.0) * 2 * np.pi / 365.2422
+        β = np.sqrt(1 - ecc**2)
         λ_m0 = -2.0 * (
-            (0.5*ecc + 0.125*ecc**3)*(1+β)*np.sin(-ω)
-            - 0.25*ecc**2*(0.5+β)*np.sin(-2*ω)
-            + 0.125*ecc**3*(1/3+β)*np.sin(-3*ω)
+            (0.5 * ecc + 0.125 * ecc**3) * (1 + β) * np.sin(-ω)
+            - 0.25 * ecc**2 * (0.5 + β) * np.sin(-2 * ω)
+            + 0.125 * ecc**3 * (1 / 3 + β) * np.sin(-3 * ω)
         )
-        λ_m  = λ_m0 + Δλ_m
-        λ    = (
+        λ_m = λ_m0 + Δλ_m
+        λ = (
             λ_m
-            + (2*ecc - 0.25*ecc**3)*np.sin(λ_m - ω)
-            + 1.25*ecc**2*np.sin(2*(λ_m - ω))
-            + (13/12)*ecc**3*np.sin(3*(λ_m - ω))
+            + (2 * ecc - 0.25 * ecc**3) * np.sin(λ_m - ω)
+            + 1.25 * ecc**2 * np.sin(2 * (λ_m - ω))
+            + (13 / 12) * ecc**3 * np.sin(3 * (λ_m - ω))
         )
     elif day_type == 2:
-        λ = day * 2*np.pi/360.0
+        λ = day * 2 * np.pi / 360.0
     else:
         raise ValueError("Invalid day_type")
 
     So = 1365.0
-    δ  = np.arcsin(np.sin(ε)*np.sin(λ))
-    H0 = np.arccos(-np.tan(φ)*np.tan(δ))
+    δ = np.arcsin(np.sin(ε) * np.sin(λ))
+    H0 = np.arccos(-np.tan(φ) * np.tan(δ))
 
-    # no sunrise / no sunset adjustments
-    mask1 = (np.abs(φ) >= (np.pi/2 - np.abs(δ))) & (φ*δ > 0)
-    mask2 = (np.abs(φ) >= (np.pi/2 - np.abs(δ))) & (φ*δ <= 0)
+    mask1 = (np.abs(φ) >= (np.pi / 2 - np.abs(δ))) & (φ * δ > 0)
+    mask2 = (np.abs(φ) >= (np.pi / 2 - np.abs(δ))) & (φ * δ <= 0)
     H0 = np.where(mask1, np.pi, H0)
     H0 = np.where(mask2, 0.0, H0)
 
     Fsw = (
-        So/np.pi
-        * (1 + ecc*np.cos(λ - ω))**2
-        / (1 - ecc**2)**2
-        * (H0*np.sin(φ)*np.sin(δ) + np.cos(φ)*np.cos(δ)*np.sin(H0))
+        So
+        / np.pi
+        * (1 + ecc * np.cos(λ - ω)) ** 2
+        / (1 - ecc**2) ** 2
+        * (H0 * np.sin(φ) * np.sin(δ) + np.cos(φ) * np.cos(δ) * np.sin(H0))
     )
 
     return {
-        'Fsw':        Fsw,
-        'ecc':        ecc,
-        'obliquity':  obliquity,
-        'long_perh':  long_perh,
-        'lambda':     np.rad2deg(λ) % 360.0
+        "Fsw": Fsw,
+        "ecc": ecc,
+        "obliquity": obliquity,
+        "long_perh": long_perh,
+        "lambda": np.rad2deg(λ) % 360.0,
     }
 
-def daily_insolation(kyear, lat, day, day_type=1, fast=True):
-    """
-    Translated from R's daily_insolation.
-    kyear scalar or array, lat in degrees,
-    day scalar or array of days 1–365.24 or solar longitudes.
-    """
+
+def daily_insolation(
+    kyear: float, lat: float, day: np.ndarray, day_type: int = 1, fast: bool = True
+) -> dict:
     if fast:
         ecc, ε, ω = orbital_parameters_fast(kyear)
     else:
         ecc, ε, ω = orbital_parameters(kyear)
 
-    # reuse daily_insolation_param by converting back to degrees
     return daily_insolation_param(
-        lat, day,
-        ecc, np.rad2deg(ε), np.rad2deg(ω),
-        day_type=day_type
+        lat,
+        day,
+        ecc,
+        np.rad2deg(ε),
+        np.rad2deg(ω),
+        day_type=day_type,
     )
 
-def annual_insolation(kyears, lat):
-    """
-    Equivalent to R's annual_insolation: mean over days 1–365.
-    """
+
+def annual_insolation(kyears: np.ndarray, lat: float) -> np.ndarray:
     kyears = np.atleast_1d(kyears)
     out = np.empty_like(kyears, dtype=float)
     for i, ky in enumerate(kyears):
-        res = daily_insolation(ky, lat, np.arange(1,366), day_type=1, fast=True)
-        out[i] = np.mean(res['Fsw'])
+        res = daily_insolation(ky, lat, np.arange(1, 366), day_type=1, fast=True)
+        out[i] = np.mean(res["Fsw"])
     return out
 
-def ins_march21(kyear, lat):
-    """Daily Fsw for days 1–365, March‐21 calendar."""
-    return daily_insolation(kyear, lat, np.arange(1,366))['Fsw']
 
-def ins_dec21(kyear, lat):
-    """Align so that day=1 corresponds to Dec‐21 solstice."""
-    r = daily_insolation(kyear, lat, np.arange(1,366))
-    lam = r['lambda']
+def ins_march21(kyear: float, lat: float) -> np.ndarray:
+    return daily_insolation(kyear, lat, np.arange(1, 366))["Fsw"]
+
+
+def ins_dec21(kyear: float, lat: float) -> np.ndarray:
+    r = daily_insolation(kyear, lat, np.arange(1, 366))
+    lam = r["lambda"]
     shift = 355 - np.argmin(np.abs(lam - 270))
-    return tlag(r['Fsw'], shift)
-
-def ins_dec21_param(ecc, obliquity, long_perh, lat):
-    r = daily_insolation_param(lat, np.arange(1,366), ecc, obliquity, long_perh)
-    shift = 355 - np.argmin(np.abs(r['lambda'] - 270))
-    return tlag(r['Fsw'], shift)
+    return tlag(r["Fsw"], shift)
 
 
-# In[6]:
+def ins_dec21_param(
+    ecc: float, obliquity: float, long_perh: float, lat: float
+) -> np.ndarray:
+    r = daily_insolation_param(lat, np.arange(1, 366), ecc, obliquity, long_perh)
+    shift = 355 - np.argmin(np.abs(r["lambda"] - 270))
+    return tlag(r["Fsw"], shift)
 
 
-# June 21 at 65°N over last 5 Myr
-june65 = np.array([daily_insolation(i, 65, 172)['Fsw'] for i in range(1,5001)])
-times = -np.arange(1,5001)
+def main() -> None:
+    _ensure_orbital_data_loaded()
 
-plt.figure()
-plt.plot(times, june65, 'r-')
-plt.xlabel('kyr BP')
-plt.ylabel('Insolation (W/m²)')
-plt.title('June 21 at 65°N')
-plt.show()
+    june65 = np.array([daily_insolation(i, 65, 172)["Fsw"] for i in range(1, 5001)])
+    times = -np.arange(1, 5001)
+    print(f"Computed June 21 insolation at 65°N for {len(june65)} kyr.")
+    print(f"Mean insolation over this period: {june65.mean():.2f} W/m²")
+
+    fig, ax = plt.subplots()
+    ax.plot(times, june65, "r-")
+    ax.set_xlabel("kyr BP")
+    ax.set_ylabel("Insolation (W/m²)")
+    ax.set_title("June 21 Insolation at 65°N")
+    ax.grid(True)
+    _save_figure(fig, "june21_65N_timeseries")
+
+    wave = june65.copy()
+    wave[wave > 510] = 510
+    fig, ax = plt.subplots()
+    ax.plot(times, wave, "-")
+    ax.axhline(june65.mean(), linestyle="--", color="black", label="Mean")
+    ax.set_xlabel("kyr BP")
+    ax.set_ylabel("Insolation (W/m²)")
+    ax.set_title("Clipped Insolation at 65°N (June 21)")
+    ax.legend()
+    ax.grid(True)
+    _save_figure(fig, "june21_65N_clipped")
+
+    ecc_new = np.array([daily_insolation(i, 65, 172)["ecc"] for i in range(1, 5001)])
+    obliq_new = np.array(
+        [daily_insolation(i, 65, 172)["obliquity"] for i in range(1, 5001)]
+    )
+    perihel_new = np.array(
+        [daily_insolation(i, 65, 172)["lambda"] for i in range(1, 5001)]
+    )
+
+    fig, ax = plt.subplots()
+    ax.plot(times, ecc_new, "r-")
+    ax.set_title("Eccentricity")
+    ax.set_xlabel("kyr BP")
+    ax.set_ylabel("Eccentricity")
+    ax.grid(True)
+    _save_figure(fig, "orbital_eccentricity")
+
+    fig, ax = plt.subplots()
+    ax.plot(times, obliq_new, "b-")
+    ax.set_title("Obliquity")
+    ax.set_xlabel("kyr BP")
+    ax.set_ylabel("Degrees")
+    ax.grid(True)
+    _save_figure(fig, "orbital_obliquity")
+
+    fig, ax = plt.subplots()
+    ax.plot(times, perihel_new, "k-")
+    ax.set_title("Solar Longitude λ")
+    ax.set_xlabel("kyr BP")
+    ax.set_ylabel("Degrees")
+    ax.grid(True)
+    _save_figure(fig, "orbital_solar_longitude")
+
+    threekBP65 = np.array([daily_insolation(0, 65, i)["Fsw"] for i in range(1, 365)])
+    fifteenBP65 = np.array([daily_insolation(12, 65, i)["Fsw"] for i in range(1, 365)])
+    thirtyBP65 = np.array([daily_insolation(5, 65, i)["Fsw"] for i in range(1, 365)])
+    days = np.arange(1, 365)
+
+    fig, ax = plt.subplots()
+    ax.plot(days, threekBP65, "r-", label="0 kyr BP")
+    ax.plot(days, fifteenBP65, "b-", label="12 kyr BP")
+    ax.plot(days, thirtyBP65, "g-", label="5 kyr BP")
+    ax.set_xlabel("Day of Year")
+    ax.set_ylabel("Daily Insolation (W/m²)")
+    ax.set_title("Daily Insolation at 65°N")
+    ax.legend()
+    ax.grid(True)
+    _save_figure(fig, "daily_insolation_65N_comparison")
 
 
-# In[7]:
-
-
-# Clip wave at 510, plot mean line
-wave = june65.copy()
-wave[wave > 510] = 510
-plt.figure()
-plt.plot(times, wave, '-')
-plt.axhline(june65.mean(), linestyle='--')
-plt.title('Clipped Insolation, 65°N on June 21')
-plt.show()
-
-
-# In[8]:
-
-
-# Plot orbital parameters
-ecc_new       = np.array([daily_insolation(i,65,172)['ecc'] for i in range(1,5001)])
-obliq_new     = np.array([daily_insolation(i,65,172)['obliquity'] for i in range(1,5001)])
-perihel_new   = np.array([daily_insolation(i,65,172)['lambda'] for i in range(1,5001)])
-plt.figure(); plt.plot(times, ecc_new, 'r-'); plt.title('Eccentricity'); plt.show()
-plt.figure(); plt.plot(times, obliq_new, 'b-'); plt.title('Obliquity (deg)'); plt.show()
-plt.figure(); plt.plot(times, perihel_new, 'k-'); plt.title('Solar Longitude λ'); plt.show()
-
-
-# In[16]:
-
-
-# June 21 at 65°N over last 5 Myr
-threekBP65 = np.array([daily_insolation(0, 65, i)['Fsw'] for i in range(1,365)])
-thirtyBP65 = np.array([daily_insolation(5, 65, i)['Fsw'] for i in range(1,365)])
-
-fifteenBP65 = np.array([daily_insolation(12, 65, i)['Fsw'] for i in range(1,365)])
-
-times = np.arange(1,365)
-
-plt.figure()
-plt.plot(times, threekBP65, 'r-')
-plt.plot(times, fifteenBP65, 'b-')
-plt.plot(times, thirtyBP65, 'g-')
-plt.xlabel('kyr BP')
-plt.ylabel('Daily Insolation (W/m²)')
-plt.title('June 21 at 65°N')
-plt.show()
-
-
-# In[ ]:
-
-
-
-
+if __name__ == "__main__":
+    main()

--- a/src/explore-double-sawtooth.py
+++ b/src/explore-double-sawtooth.py
@@ -1,4 +1,5 @@
 """Explore combinations of sawtooth wave constructions and save the figures."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -24,7 +25,9 @@ def sawtooth(t: np.ndarray, period: float) -> np.ndarray:
     return np.mod(t, period)
 
 
-def sawtooth_centered(t: np.ndarray, period: float, zero_point: float, slope: float = 1.0) -> np.ndarray:
+def sawtooth_centered(
+    t: np.ndarray, period: float, zero_point: float, slope: float = 1.0
+) -> np.ndarray:
     return (((t - zero_point - period / 2.0) % period) - period / 2.0) * slope
 
 
@@ -36,17 +39,23 @@ def double_sawtooth(
 ) -> np.ndarray:
     st1 = sawtooth_centered(t, period, first.zero_point, first.slope)
     st2 = sawtooth_centered(t, period, second.zero_point, second.slope)
-    crossing_start = (first.zero_point * first.slope - second.zero_point * second.slope) / (
-        first.slope - second.slope
-    )
-    crossing_end = ((first.zero_point + period) * first.slope - second.zero_point * second.slope) / (
-        first.slope - second.slope
-    )
+    crossing_start = (
+        first.zero_point * first.slope - second.zero_point * second.slope
+    ) / (first.slope - second.slope)
+    crossing_end = (
+        (first.zero_point + period) * first.slope - second.zero_point * second.slope
+    ) / (first.slope - second.slope)
     mask = ((t % period) > crossing_start) & ((t % period) < crossing_end)
     return np.where(mask, st2, st1)
 
 
-def save_plot(x: np.ndarray, ys: Iterable[np.ndarray], labels: Iterable[str], title: str, name: str) -> Path:
+def save_plot(
+    x: np.ndarray,
+    ys: Iterable[np.ndarray],
+    labels: Iterable[str],
+    title: str,
+    name: str,
+) -> Path:
     fig, ax = plt.subplots(figsize=(10, 5))
     for series, label in zip(ys, labels):
         ax.plot(x, series, label=label)
@@ -105,13 +114,12 @@ if __name__ == "__main__":
     print(f"Saved scaled comparison figure -> {combined_path}")
 
     crossing = (
-        (increase.zero_point * increase.slope - decrease.zero_point * decrease.slope)
-        / (increase.slope - decrease.slope)
-    )
+        increase.zero_point * increase.slope - decrease.zero_point * decrease.slope
+    ) / (increase.slope - decrease.slope)
     crossing_mod = (
-        ((increase.zero_point + period) * increase.slope - decrease.zero_point * decrease.slope)
-        / (increase.slope - decrease.slope)
-    )
+        (increase.zero_point + period) * increase.slope
+        - decrease.zero_point * decrease.slope
+    ) / (increase.slope - decrease.slope)
     print(
         "Crossing windows between increase/decrease segments: "
         f"{crossing:.2f} to {crossing_mod:.2f} (mod {period:.0f})"

--- a/src/process_priority.py
+++ b/src/process_priority.py
@@ -1,4 +1,5 @@
 """Utilities for adjusting the scheduling priority of processes."""
+
 from __future__ import annotations
 
 import os

--- a/src/re-chunk-h5-file.py
+++ b/src/re-chunk-h5-file.py
@@ -4,11 +4,8 @@
 # In[1]:
 
 
-import os
 import h5py
 import numpy as np
-import pandas as pd
-import matplotlib.pyplot as plt
 
 
 # In[2]:
@@ -50,7 +47,7 @@ with h5py.File(old_hdf5_file, "r") as old_h5f, h5py.File(new_hdf5_file, "w") as 
         shape=old_data.shape,
         dtype=old_data.dtype,
         chunks=new_chunk_size,
-        compression="lzf"
+        compression="lzf",
     )
 
     # Copy data in chunks to avoid memory issues
@@ -71,10 +68,15 @@ with h5py.File(old_file, "r") as old_h5, h5py.File(new_file, "r") as new_h5:
     print("New shape:", new_h5["ndvi_stack"].shape)
     print("Old dtype:", old_h5["ndvi_stack"].dtype)
     print("New dtype:", new_h5["ndvi_stack"].dtype)
-    
+
     # Compare random samples
     idx = np.random.randint(0, old_h5["ndvi_stack"].shape[0])
-    print("Sample comparison:", np.allclose(old_h5["ndvi_stack"][idx], new_h5["ndvi_stack"][idx], equal_nan=True))
+    print(
+        "Sample comparison:",
+        np.allclose(
+            old_h5["ndvi_stack"][idx], new_h5["ndvi_stack"][idx], equal_nan=True
+        ),
+    )
 
 
 # In[7]:
@@ -102,7 +104,7 @@ with h5py.File(old_hdf5_file, "r") as old_h5f, h5py.File(new_hdf5_file, "w") as 
         shape=old_data.shape,
         dtype=old_data.dtype,
         chunks=new_chunk_size,
-        compression="lzf"
+        compression="lzf",
     )
 
     # Copy data in chunks to avoid memory issues
@@ -137,7 +139,7 @@ with h5py.File(old_hdf5_file, "r") as old_h5f, h5py.File(new_hdf5_file, "w") as 
         shape=old_data.shape,
         dtype=old_data.dtype,
         chunks=new_chunk_size,
-        compression="lzf"
+        compression="lzf",
     )
 
     # Copy data in chunks to avoid memory issues
@@ -148,7 +150,3 @@ print(f"Optimized HDF5 saved to {new_hdf5_file}")
 
 
 # In[ ]:
-
-
-
-


### PR DESCRIPTION
## Summary
- standardize the NDVI fitting scripts to slugify figure names, print progress, and handle scaled inputs safely
- harden the Europe-wide batch regression driver with cleaner logging and consistent curve fitting helpers
- refresh the insolation plotting pipeline to lazily load orbital data and persist each plot to the shared figure directory
- resolve repository lint issues by formatting the source tree and removing unused variables and imports

## Testing
- `black src`
- `ruff check src`


------
https://chatgpt.com/codex/tasks/task_e_68dbe64d51e08328889e5358d7f3264e